### PR TITLE
Switch DieReleaseUnstructured to return *unstructured.Unstructured

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ type MyResourceDie interface {
 
     // DieReleaseUnstructured returns the resource managed by the die as an
     // unstructured object.
-    DieReleaseUnstructured() runtime.Unstructured
+    DieReleaseUnstructured() *unstructured.Unstructured
 
     // MetadataDie stamps the resource's ObjectMeta field with a mutable die.
     MetadataDie(fn func(d *diemetav1.ObjectMetaDie)) *MyResourceDie

--- a/apis/admissionregistration/v1/zz_generated.die.go
+++ b/apis/admissionregistration/v1/zz_generated.die.go
@@ -540,7 +540,7 @@ func (d *MutatingWebhookConfigurationDie) DieReleasePtr() *admissionregistration
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *MutatingWebhookConfigurationDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *MutatingWebhookConfigurationDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -876,7 +876,7 @@ func (d *ValidatingWebhookConfigurationDie) DieReleasePtr() *admissionregistrati
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ValidatingWebhookConfigurationDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ValidatingWebhookConfigurationDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/apiextensions/v1/zz_generated.die.go
+++ b/apis/apiextensions/v1/zz_generated.die.go
@@ -94,7 +94,7 @@ func (d *CustomResourceDefinitionDie) DieReleasePtr() *apiextensionsv1.CustomRes
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *CustomResourceDefinitionDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *CustomResourceDefinitionDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/apiregistration/v1/zz_generated.die.go
+++ b/apis/apiregistration/v1/zz_generated.die.go
@@ -94,7 +94,7 @@ func (d *APIServiceDie) DieReleasePtr() *apiregistration.APIService {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *APIServiceDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *APIServiceDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/apiserver/flowcontrol/v1beta1/zz_generated.die.go
+++ b/apis/apiserver/flowcontrol/v1beta1/zz_generated.die.go
@@ -94,7 +94,7 @@ func (d *FlowSchemaDie) DieReleasePtr() *flowcontrolv1beta1.FlowSchema {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *FlowSchemaDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *FlowSchemaDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -1373,7 +1373,7 @@ func (d *PriorityLevelConfigurationDie) DieReleasePtr() *flowcontrolv1beta1.Prio
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *PriorityLevelConfigurationDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *PriorityLevelConfigurationDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/apps/v1/zz_generated.die.go
+++ b/apis/apps/v1/zz_generated.die.go
@@ -97,7 +97,7 @@ func (d *ControllerRevisionDie) DieReleasePtr() *appsv1.ControllerRevision {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ControllerRevisionDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ControllerRevisionDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -259,7 +259,7 @@ func (d *DaemonSetDie) DieReleasePtr() *appsv1.DaemonSet {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *DaemonSetDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *DaemonSetDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -936,7 +936,7 @@ func (d *DeploymentDie) DieReleasePtr() *appsv1.Deployment {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *DeploymentDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *DeploymentDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -1620,7 +1620,7 @@ func (d *ReplicaSetDie) DieReleasePtr() *appsv1.ReplicaSet {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ReplicaSetDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ReplicaSetDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -2038,7 +2038,7 @@ func (d *StatefulSetDie) DieReleasePtr() *appsv1.StatefulSet {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *StatefulSetDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *StatefulSetDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/authentication/v1/zz_generated.die.go
+++ b/apis/authentication/v1/zz_generated.die.go
@@ -96,7 +96,7 @@ func (d *TokenReviewDie) DieReleasePtr() *authenticationv1.TokenReview {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *TokenReviewDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *TokenReviewDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/authorization/rbac/v1/zz_generated.die.go
+++ b/apis/authorization/rbac/v1/zz_generated.die.go
@@ -95,7 +95,7 @@ func (d *ClusterRoleDie) DieReleasePtr() *rbacv1.ClusterRole {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ClusterRoleDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ClusterRoleDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -348,7 +348,7 @@ func (d *ClusterRoleBindingDie) DieReleasePtr() *rbacv1.ClusterRoleBinding {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ClusterRoleBindingDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ClusterRoleBindingDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -510,7 +510,7 @@ func (d *RoleDie) DieReleasePtr() *rbacv1.Role {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *RoleDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *RoleDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -784,7 +784,7 @@ func (d *RoleBindingDie) DieReleasePtr() *rbacv1.RoleBinding {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *RoleBindingDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *RoleBindingDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/authorization/v1/zz_generated.die.go
+++ b/apis/authorization/v1/zz_generated.die.go
@@ -94,7 +94,7 @@ func (d *LocalSubjectAccessReviewDie) DieReleasePtr() *authorizationv1.LocalSubj
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *LocalSubjectAccessReviewDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *LocalSubjectAccessReviewDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -256,7 +256,7 @@ func (d *SelfSubjectAccessReviewDie) DieReleasePtr() *authorizationv1.SelfSubjec
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *SelfSubjectAccessReviewDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *SelfSubjectAccessReviewDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -534,7 +534,7 @@ func (d *SelfSubjectRulesReviewDie) DieReleasePtr() *authorizationv1.SelfSubject
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *SelfSubjectRulesReviewDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *SelfSubjectRulesReviewDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -1127,7 +1127,7 @@ func (d *SubjectAccessReviewDie) DieReleasePtr() *authorizationv1.SubjectAccessR
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *SubjectAccessReviewDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *SubjectAccessReviewDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/autoscaling/v1/zz_generated.die.go
+++ b/apis/autoscaling/v1/zz_generated.die.go
@@ -95,7 +95,7 @@ func (d *HorizontalPodAutoscalerDie) DieReleasePtr() *autoscalingv1.HorizontalPo
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *HorizontalPodAutoscalerDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *HorizontalPodAutoscalerDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/batch/v1/zz_generated.die.go
+++ b/apis/batch/v1/zz_generated.die.go
@@ -97,7 +97,7 @@ func (d *CronJobDie) DieReleasePtr() *batchv1.CronJob {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *CronJobDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *CronJobDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -522,7 +522,7 @@ func (d *JobDie) DieReleasePtr() *batchv1.Job {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *JobDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *JobDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/certificates/v1/zz_generated.die.go
+++ b/apis/certificates/v1/zz_generated.die.go
@@ -94,7 +94,7 @@ func (d *CertificateSigningRequestDie) DieReleasePtr() *certificatesv1.Certifica
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *CertificateSigningRequestDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *CertificateSigningRequestDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/coordination/v1/zz_generated.die.go
+++ b/apis/coordination/v1/zz_generated.die.go
@@ -95,7 +95,7 @@ func (d *LeaseDie) DieReleasePtr() *coordinationv1.Lease {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *LeaseDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *LeaseDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/core/v1/zz_generated.die.go
+++ b/apis/core/v1/zz_generated.die.go
@@ -98,7 +98,7 @@ func (d *BindingDie) DieReleasePtr() *corev1.Binding {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *BindingDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *BindingDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -869,7 +869,7 @@ func (d *ComponentStatusDie) DieReleasePtr() *corev1.ComponentStatus {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ComponentStatusDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ComponentStatusDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -1024,7 +1024,7 @@ func (d *ConfigMapDie) DieReleasePtr() *corev1.ConfigMap {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ConfigMapDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ConfigMapDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -4928,7 +4928,7 @@ func (d *EndpointsDie) DieReleasePtr() *corev1.Endpoints {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *EndpointsDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *EndpointsDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -5412,7 +5412,7 @@ func (d *EventDie) DieReleasePtr() *corev1.Event {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *EventDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *EventDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -5854,7 +5854,7 @@ func (d *LimitRangeDie) DieReleasePtr() *corev1.LimitRange {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *LimitRangeDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *LimitRangeDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -6235,7 +6235,7 @@ func (d *NamespaceDie) DieReleasePtr() *corev1.Namespace {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *NamespaceDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *NamespaceDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -6604,7 +6604,7 @@ func (d *NodeDie) DieReleasePtr() *corev1.Node {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *NodeDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *NodeDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -8142,7 +8142,7 @@ func (d *PersistentVolumeDie) DieReleasePtr() *corev1.PersistentVolume {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *PersistentVolumeDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *PersistentVolumeDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -10366,7 +10366,7 @@ func (d *PersistentVolumeClaimDie) DieReleasePtr() *corev1.PersistentVolumeClaim
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *PersistentVolumeClaimDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *PersistentVolumeClaimDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -10910,7 +10910,7 @@ func (d *PodDie) DieReleasePtr() *corev1.Pod {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *PodDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *PodDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -12621,7 +12621,7 @@ func (d *PodTemplateDie) DieReleasePtr() *corev1.PodTemplate {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *PodTemplateDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *PodTemplateDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -12874,7 +12874,7 @@ func (d *ReplicationControllerDie) DieReleasePtr() *corev1.ReplicationController
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ReplicationControllerDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ReplicationControllerDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -13292,7 +13292,7 @@ func (d *ResourceQuotaDie) DieReleasePtr() *corev1.ResourceQuota {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ResourceQuotaDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ResourceQuotaDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -13871,7 +13871,7 @@ func (d *SecretDie) DieReleasePtr() *corev1.Secret {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *SecretDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *SecretDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -14033,7 +14033,7 @@ func (d *ServiceDie) DieReleasePtr() *corev1.Service {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ServiceDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ServiceDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -15155,7 +15155,7 @@ func (d *ServiceAccountDie) DieReleasePtr() *corev1.ServiceAccount {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *ServiceAccountDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *ServiceAccountDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/events/v1/zz_generated.die.go
+++ b/apis/events/v1/zz_generated.die.go
@@ -96,7 +96,7 @@ func (d *EventDie) DieReleasePtr() *eventsv1.Event {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *EventDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *EventDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/networking/v1/zz_generated.die.go
+++ b/apis/networking/v1/zz_generated.die.go
@@ -97,7 +97,7 @@ func (d *IngressDie) DieReleasePtr() *networkingv1.Ingress {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *IngressDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *IngressDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -1168,7 +1168,7 @@ func (d *IngressClassDie) DieReleasePtr() *networkingv1.IngressClass {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *IngressClassDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *IngressClassDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -1549,7 +1549,7 @@ func (d *NetworkPolicyDie) DieReleasePtr() *networkingv1.NetworkPolicy {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *NetworkPolicyDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *NetworkPolicyDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/node/v1/zz_generated.die.go
+++ b/apis/node/v1/zz_generated.die.go
@@ -95,7 +95,7 @@ func (d *RuntimeClassDie) DieReleasePtr() *nodev1.RuntimeClass {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *RuntimeClassDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *RuntimeClassDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/policy/v1/zz_generated.die.go
+++ b/apis/policy/v1/zz_generated.die.go
@@ -96,7 +96,7 @@ func (d *PodDisruptionBudgetDie) DieReleasePtr() *policyv1.PodDisruptionBudget {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *PodDisruptionBudgetDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *PodDisruptionBudgetDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/policy/v1beta1/zz_generated.die.go
+++ b/apis/policy/v1beta1/zz_generated.die.go
@@ -95,7 +95,7 @@ func (d *PodSecurityPolicyDie) DieReleasePtr() *policyv1beta1.PodSecurityPolicy 
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *PodSecurityPolicyDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *PodSecurityPolicyDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/scheduling/v1/zz_generated.die.go
+++ b/apis/scheduling/v1/zz_generated.die.go
@@ -95,7 +95,7 @@ func (d *PriorityClassDie) DieReleasePtr() *schedulingv1.PriorityClass {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *PriorityClassDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *PriorityClassDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/storage/v1/zz_generated.die.go
+++ b/apis/storage/v1/zz_generated.die.go
@@ -96,7 +96,7 @@ func (d *CSIDriverDie) DieReleasePtr() *storagev1.CSIDriver {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *CSIDriverDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *CSIDriverDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -526,7 +526,7 @@ func (d *CSINodeDie) DieReleasePtr() *storagev1.CSINode {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *CSINodeDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *CSINodeDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -984,7 +984,7 @@ func (d *StorageClassDie) DieReleasePtr() *storagev1.StorageClass {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *StorageClassDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *StorageClassDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{
@@ -1181,7 +1181,7 @@ func (d *VolumeAttachmentDie) DieReleasePtr() *storagev1.VolumeAttachment {
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *VolumeAttachmentDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *VolumeAttachmentDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/apis/storage/v1beta1/zz_generated.die.go
+++ b/apis/storage/v1beta1/zz_generated.die.go
@@ -96,7 +96,7 @@ func (d *CSIStorageCapacityDie) DieReleasePtr() *storagev1beta1.CSIStorageCapaci
 }
 
 // DieReleaseUnstructured returns the resource managed by the die as an unstructured object.
-func (d *CSIStorageCapacityDie) DieReleaseUnstructured() runtime.Unstructured {
+func (d *CSIStorageCapacityDie) DieReleaseUnstructured() *unstructured.Unstructured {
 	r := d.DieReleasePtr()
 	u, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(r)
 	return &unstructured.Unstructured{

--- a/diegen/die/traverse.go
+++ b/diegen/die/traverse.go
@@ -281,7 +281,7 @@ func (c *copyMethodMaker) generateDieReleaseMethodFor(die Die) {
 	if die.Object {
 		c.Linef("")
 		c.Linef("// DieReleaseUnstructured returns the resource managed by the die as an unstructured object.")
-		c.Linef("func (d *%s) DieReleaseUnstructured() %s {", die.Type, c.AliasedRef("k8s.io/apimachinery/pkg/runtime", "Unstructured"))
+		c.Linef("func (d *%s) DieReleaseUnstructured() *%s {", die.Type, c.AliasedRef("k8s.io/apimachinery/pkg/apis/meta/v1/unstructured", "Unstructured"))
 		c.Linef("	r := d.DieReleasePtr()")
 		c.Linef("	u, _ := %s.ToUnstructured(r)", c.AliasedRef("k8s.io/apimachinery/pkg/runtime", "DefaultUnstructuredConverter"))
 		c.Linef("	return &%s{", c.AliasedRef("k8s.io/apimachinery/pkg/apis/meta/v1/unstructured", "Unstructured"))


### PR DESCRIPTION
`DieReleaseUnstructured` previously returned the interface
`runtime.Unstructured`, it now returns `*unstructured.Unstructured`
which is compatible with the previous interface, but also implements
`metav1.Object` in addition to `runtime.Object`.

Supporting both object interfaces is useful when working with
controller-runtime to avoid needing to cast the type.

Signed-off-by: Scott Andrews <scott@andrews.me>