### PR TITLE
Initialize nil maps before setting key

### DIFF
--- a/apis/core/v1/container.go
+++ b/apis/core/v1/container.go
@@ -264,6 +264,9 @@ type _ = corev1.ResourceRequirements
 
 func (d *ResourceRequirementsDie) AddLimit(name corev1.ResourceName, quantity resource.Quantity) *ResourceRequirementsDie {
 	return d.DieStamp(func(r *corev1.ResourceRequirements) {
+		if r.Limits == nil {
+			r.Limits = corev1.ResourceList{}
+		}
 		r.Limits[name] = quantity
 	})
 }
@@ -274,6 +277,9 @@ func (d *ResourceRequirementsDie) AddLimitString(name corev1.ResourceName, quant
 
 func (d *ResourceRequirementsDie) AddRequest(name corev1.ResourceName, quantity resource.Quantity) *ResourceRequirementsDie {
 	return d.DieStamp(func(r *corev1.ResourceRequirements) {
+		if r.Requests == nil {
+			r.Requests = corev1.ResourceList{}
+		}
 		r.Requests[name] = quantity
 	})
 }

--- a/apis/core/v1/limitrange.go
+++ b/apis/core/v1/limitrange.go
@@ -41,6 +41,9 @@ type _ = corev1.LimitRangeItem
 
 func (d *LimitRangeItemDie) AddMax(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
 	return d.DieStamp(func(r *corev1.LimitRangeItem) {
+		if r.Max == nil {
+			r.Max = corev1.ResourceList{}
+		}
 		r.Max[name] = quantity
 	})
 }
@@ -51,6 +54,9 @@ func (d *LimitRangeItemDie) AddMaxString(name corev1.ResourceName, quantity stri
 
 func (d *LimitRangeItemDie) AddMin(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
 	return d.DieStamp(func(r *corev1.LimitRangeItem) {
+		if r.Min == nil {
+			r.Min = corev1.ResourceList{}
+		}
 		r.Min[name] = quantity
 	})
 }
@@ -61,6 +67,9 @@ func (d *LimitRangeItemDie) AddMinString(name corev1.ResourceName, quantity stri
 
 func (d *LimitRangeItemDie) AddDefault(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
 	return d.DieStamp(func(r *corev1.LimitRangeItem) {
+		if r.Default == nil {
+			r.Default = corev1.ResourceList{}
+		}
 		r.Default[name] = quantity
 	})
 }
@@ -71,6 +80,9 @@ func (d *LimitRangeItemDie) AddDefaultString(name corev1.ResourceName, quantity 
 
 func (d *LimitRangeItemDie) AddDefaultRequest(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
 	return d.DieStamp(func(r *corev1.LimitRangeItem) {
+		if r.DefaultRequest == nil {
+			r.DefaultRequest = corev1.ResourceList{}
+		}
 		r.DefaultRequest[name] = quantity
 	})
 }
@@ -81,6 +93,9 @@ func (d *LimitRangeItemDie) AddDefaultRequestString(name corev1.ResourceName, qu
 
 func (d *LimitRangeItemDie) AddMaxLimitRequestRatio(name corev1.ResourceName, quantity resource.Quantity) *LimitRangeItemDie {
 	return d.DieStamp(func(r *corev1.LimitRangeItem) {
+		if r.MaxLimitRequestRatio == nil {
+			r.MaxLimitRequestRatio = corev1.ResourceList{}
+		}
 		r.MaxLimitRequestRatio[name] = quantity
 	})
 }

--- a/apis/core/v1/node.go
+++ b/apis/core/v1/node.go
@@ -75,6 +75,9 @@ type _ = corev1.NodeStatus
 
 func (d *NodeStatusDie) AddCapacity(name corev1.ResourceName, quantity resource.Quantity) *NodeStatusDie {
 	return d.DieStamp(func(r *corev1.NodeStatus) {
+		if r.Capacity == nil {
+			r.Capacity = corev1.ResourceList{}
+		}
 		r.Capacity[name] = quantity
 	})
 }
@@ -85,6 +88,9 @@ func (d *NodeStatusDie) AddCapacityString(name corev1.ResourceName, quantity str
 
 func (d *NodeStatusDie) AddAllocatable(name corev1.ResourceName, quantity resource.Quantity) *NodeStatusDie {
 	return d.DieStamp(func(r *corev1.NodeStatus) {
+		if r.Allocatable == nil {
+			r.Allocatable = corev1.ResourceList{}
+		}
 		r.Allocatable[name] = quantity
 	})
 }

--- a/apis/core/v1/persistantvolume.go
+++ b/apis/core/v1/persistantvolume.go
@@ -29,6 +29,9 @@ type _ = corev1.PersistentVolumeSpec
 
 func (d *PersistentVolumeSpecDie) AddCapacity(name corev1.ResourceName, quantity resource.Quantity) *PersistentVolumeSpecDie {
 	return d.DieStamp(func(r *corev1.PersistentVolumeSpec) {
+		if r.Capacity == nil {
+			r.Capacity = corev1.ResourceList{}
+		}
 		r.Capacity[name] = quantity
 	})
 }

--- a/apis/core/v1/persistantvolumeclaim.go
+++ b/apis/core/v1/persistantvolumeclaim.go
@@ -65,6 +65,9 @@ type _ = corev1.PersistentVolumeClaimStatus
 
 func (d *PersistentVolumeClaimStatusDie) AddCapacity(name corev1.ResourceName, quantity resource.Quantity) *PersistentVolumeClaimStatusDie {
 	return d.DieStamp(func(r *corev1.PersistentVolumeClaimStatus) {
+		if r.Capacity == nil {
+			r.Capacity = corev1.ResourceList{}
+		}
 		r.Capacity[name] = quantity
 	})
 }
@@ -91,6 +94,9 @@ func (d *PersistentVolumeClaimStatusDie) ConditionsDie(conditions ...*diemetav1.
 
 func (d *PersistentVolumeClaimStatusDie) AddAllocatedResources(name corev1.ResourceName, quantity resource.Quantity) *PersistentVolumeClaimStatusDie {
 	return d.DieStamp(func(r *corev1.PersistentVolumeClaimStatus) {
+		if r.AllocatedResources == nil {
+			r.AllocatedResources = corev1.ResourceList{}
+		}
 		r.AllocatedResources[name] = quantity
 	})
 }

--- a/apis/core/v1/pod.go
+++ b/apis/core/v1/pod.go
@@ -132,6 +132,9 @@ func (d *PodSpecDie) ReadinessGatesDie(gates ...*PodReadinessGateDie) *PodSpecDi
 
 func (d *PodSpecDie) AddOverhead(name corev1.ResourceName, quantity resource.Quantity) *PodSpecDie {
 	return d.DieStamp(func(r *corev1.PodSpec) {
+		if r.Overhead == nil {
+			r.Overhead = corev1.ResourceList{}
+		}
 		r.Overhead[name] = quantity
 	})
 }

--- a/apis/core/v1/resourcequota.go
+++ b/apis/core/v1/resourcequota.go
@@ -29,6 +29,9 @@ type _ = corev1.ResourceQuotaSpec
 
 func (d *ResourceQuotaSpecDie) AddHard(name corev1.ResourceName, quantity resource.Quantity) *ResourceQuotaSpecDie {
 	return d.DieStamp(func(r *corev1.ResourceQuotaSpec) {
+		if r.Hard == nil {
+			r.Hard = corev1.ResourceList{}
+		}
 		r.Hard[name] = quantity
 	})
 }
@@ -73,6 +76,9 @@ type _ = corev1.ResourceQuotaStatus
 
 func (d *ResourceQuotaStatusDie) AddHard(name corev1.ResourceName, quantity resource.Quantity) *ResourceQuotaStatusDie {
 	return d.DieStamp(func(r *corev1.ResourceQuotaStatus) {
+		if r.Hard == nil {
+			r.Hard = corev1.ResourceList{}
+		}
 		r.Hard[name] = quantity
 	})
 }
@@ -83,6 +89,9 @@ func (d *ResourceQuotaStatusDie) AddHardString(name corev1.ResourceName, quantit
 
 func (d *ResourceQuotaStatusDie) AddUsed(name corev1.ResourceName, quantity resource.Quantity) *ResourceQuotaStatusDie {
 	return d.DieStamp(func(r *corev1.ResourceQuotaStatus) {
+		if r.Used == nil {
+			r.Used = corev1.ResourceList{}
+		}
 		r.Used[name] = quantity
 	})
 }

--- a/apis/core/v1/service.go
+++ b/apis/core/v1/service.go
@@ -47,6 +47,9 @@ func (d *ServiceSpecDie) PortDie(protocol corev1.Protocol, port int32, fn func(d
 
 func (d *ServiceSpecDie) AddSelector(key, value string) *ServiceSpecDie {
 	return d.DieStamp(func(r *corev1.ServiceSpec) {
+		if r.Selector == nil {
+			r.Selector = map[string]string{}
+		}
 		r.Selector[key] = value
 	})
 }

--- a/apis/node/v1/runtimeclass.go
+++ b/apis/node/v1/runtimeclass.go
@@ -31,6 +31,9 @@ type _ = nodev1.Overhead
 
 func (d *OverheadDie) AddPodFixed(name corev1.ResourceName, quantity resource.Quantity) *OverheadDie {
 	return d.DieStamp(func(r *nodev1.Overhead) {
+		if r.PodFixed == nil {
+			r.PodFixed = corev1.ResourceList{}
+		}
 		r.PodFixed[name] = quantity
 	})
 }


### PR DESCRIPTION
Previously, about half of the `Add*()` methods that set a value in a map
checked if the map was nil before setting a field. Now they all do.

Resolves #66 

Signed-off-by: Scott Andrews <scott@andrews.me>