### PR TITLE
Add DieWith method

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ type MyResourceDie interface {
     // either mutable (`false`) or immutable (`true`). 
     DieImmutable(immutable bool) *MyResourceDie
 
+    // DieWith returns a new die after passing the current die to the callback
+    // function. The passed die is mutable.
+    DieWith(fn func(d *MyResourceDie)) *MyResourceDie
+
     // DeepCopy returns a new die with equivalent state. Useful for
     // snapshotting a mutable die.
     DeepCopy() *MyResourceDie

--- a/apis/admission/v1/zz_generated.die.go
+++ b/apis/admission/v1/zz_generated.die.go
@@ -180,6 +180,13 @@ func (d *AdmissionRequestDie) DieStampAt(jp string, fn interface{}) *AdmissionRe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AdmissionRequestDie) DieWith(fn func(d *AdmissionRequestDie)) *AdmissionRequestDie {
+	nd := AdmissionRequestBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *AdmissionRequestDie) DeepCopy() *AdmissionRequestDie {
 	r := *d.r.DeepCopy()
@@ -447,6 +454,13 @@ func (d *AdmissionResponseDie) DieStampAt(jp string, fn interface{}) *AdmissionR
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AdmissionResponseDie) DieWith(fn func(d *AdmissionResponseDie)) *AdmissionResponseDie {
+	nd := AdmissionResponseBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *AdmissionResponseDie) DeepCopy() *AdmissionResponseDie {
 	r := *d.r.DeepCopy()
@@ -648,6 +662,13 @@ func (d *AdmissionReviewDie) DieStampAt(jp string, fn interface{}) *AdmissionRev
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AdmissionReviewDie) DieWith(fn func(d *AdmissionReviewDie)) *AdmissionReviewDie {
+	nd := AdmissionReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/admissionregistration/v1/zz_generated.die.go
+++ b/apis/admissionregistration/v1/zz_generated.die.go
@@ -181,6 +181,13 @@ func (d *WebhookClientConfigDie) DieStampAt(jp string, fn interface{}) *WebhookC
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *WebhookClientConfigDie) DieWith(fn func(d *WebhookClientConfigDie)) *WebhookClientConfigDie {
+	nd := WebhookClientConfigBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *WebhookClientConfigDie) DeepCopy() *WebhookClientConfigDie {
 	r := *d.r.DeepCopy()
@@ -368,6 +375,13 @@ func (d *ServiceReferenceDie) DieStampAt(jp string, fn interface{}) *ServiceRefe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServiceReferenceDie) DieWith(fn func(d *ServiceReferenceDie)) *ServiceReferenceDie {
+	nd := ServiceReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ServiceReferenceDie) DeepCopy() *ServiceReferenceDie {
 	r := *d.r.DeepCopy()
@@ -550,6 +564,13 @@ func (d *RuleWithOperationsDie) DieStampAt(jp string, fn interface{}) *RuleWithO
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RuleWithOperationsDie) DieWith(fn func(d *RuleWithOperationsDie)) *RuleWithOperationsDie {
+	nd := RuleWithOperationsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *RuleWithOperationsDie) DeepCopy() *RuleWithOperationsDie {
 	r := *d.r.DeepCopy()
@@ -716,6 +737,13 @@ func (d *RuleDie) DieStampAt(jp string, fn interface{}) *RuleDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RuleDie) DieWith(fn func(d *RuleDie)) *RuleDie {
+	nd := RuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -906,6 +934,13 @@ func (d *MatchConditionDie) DieStampAt(jp string, fn interface{}) *MatchConditio
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *MatchConditionDie) DieWith(fn func(d *MatchConditionDie)) *MatchConditionDie {
+	nd := MatchConditionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *MatchConditionDie) DeepCopy() *MatchConditionDie {
 	r := *d.r.DeepCopy()
@@ -1093,6 +1128,13 @@ func (d *MutatingWebhookConfigurationDie) DieStampAt(jp string, fn interface{}) 
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *MutatingWebhookConfigurationDie) DieWith(fn func(d *MutatingWebhookConfigurationDie)) *MutatingWebhookConfigurationDie {
+	nd := MutatingWebhookConfigurationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1306,6 +1348,13 @@ func (d *MutatingWebhookDie) DieStampAt(jp string, fn interface{}) *MutatingWebh
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *MutatingWebhookDie) DieWith(fn func(d *MutatingWebhookDie)) *MutatingWebhookDie {
+	nd := MutatingWebhookBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1585,6 +1634,13 @@ func (d *ValidatingWebhookConfigurationDie) DieStampAt(jp string, fn interface{}
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ValidatingWebhookConfigurationDie) DieWith(fn func(d *ValidatingWebhookConfigurationDie)) *ValidatingWebhookConfigurationDie {
+	nd := ValidatingWebhookConfigurationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ValidatingWebhookConfigurationDie) DeepCopy() *ValidatingWebhookConfigurationDie {
 	r := *d.r.DeepCopy()
@@ -1796,6 +1852,13 @@ func (d *ValidatingWebhookDie) DieStampAt(jp string, fn interface{}) *Validating
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ValidatingWebhookDie) DieWith(fn func(d *ValidatingWebhookDie)) *ValidatingWebhookDie {
+	nd := ValidatingWebhookBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/apiextensions/v1/zz_generated.die.go
+++ b/apis/apiextensions/v1/zz_generated.die.go
@@ -195,6 +195,13 @@ func (d *CustomResourceDefinitionDie) DieStampAt(jp string, fn interface{}) *Cus
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CustomResourceDefinitionDie) DieWith(fn func(d *CustomResourceDefinitionDie)) *CustomResourceDefinitionDie {
+	nd := CustomResourceDefinitionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CustomResourceDefinitionDie) DeepCopy() *CustomResourceDefinitionDie {
 	r := *d.r.DeepCopy()
@@ -433,6 +440,13 @@ func (d *CustomResourceDefinitionSpecDie) DieStampAt(jp string, fn interface{}) 
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CustomResourceDefinitionSpecDie) DieWith(fn func(d *CustomResourceDefinitionSpecDie)) *CustomResourceDefinitionSpecDie {
+	nd := CustomResourceDefinitionSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CustomResourceDefinitionSpecDie) DeepCopy() *CustomResourceDefinitionSpecDie {
 	r := *d.r.DeepCopy()
@@ -627,6 +641,13 @@ func (d *CustomResourceDefinitionVersionDie) DieStampAt(jp string, fn interface{
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CustomResourceDefinitionVersionDie) DieWith(fn func(d *CustomResourceDefinitionVersionDie)) *CustomResourceDefinitionVersionDie {
+	nd := CustomResourceDefinitionVersionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -839,6 +860,13 @@ func (d *CustomResourceValidationDie) DieStampAt(jp string, fn interface{}) *Cus
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CustomResourceValidationDie) DieWith(fn func(d *CustomResourceValidationDie)) *CustomResourceValidationDie {
+	nd := CustomResourceValidationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CustomResourceValidationDie) DeepCopy() *CustomResourceValidationDie {
 	r := *d.r.DeepCopy()
@@ -998,6 +1026,13 @@ func (d *CustomResourceSubresourcesDie) DieStampAt(jp string, fn interface{}) *C
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CustomResourceSubresourcesDie) DieWith(fn func(d *CustomResourceSubresourcesDie)) *CustomResourceSubresourcesDie {
+	nd := CustomResourceSubresourcesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1166,6 +1201,13 @@ func (d *CustomResourceSubresourceScaleDie) DieStampAt(jp string, fn interface{}
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CustomResourceSubresourceScaleDie) DieWith(fn func(d *CustomResourceSubresourceScaleDie)) *CustomResourceSubresourceScaleDie {
+	nd := CustomResourceSubresourceScaleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1341,6 +1383,13 @@ func (d *CustomResourceColumnDefinitionDie) DieStampAt(jp string, fn interface{}
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CustomResourceColumnDefinitionDie) DieWith(fn func(d *CustomResourceColumnDefinitionDie)) *CustomResourceColumnDefinitionDie {
+	nd := CustomResourceColumnDefinitionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1539,6 +1588,13 @@ func (d *CustomResourceConversionDie) DieStampAt(jp string, fn interface{}) *Cus
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CustomResourceConversionDie) DieWith(fn func(d *CustomResourceConversionDie)) *CustomResourceConversionDie {
+	nd := CustomResourceConversionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CustomResourceConversionDie) DeepCopy() *CustomResourceConversionDie {
 	r := *d.r.DeepCopy()
@@ -1707,6 +1763,13 @@ func (d *WebhookConversionDie) DieStampAt(jp string, fn interface{}) *WebhookCon
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *WebhookConversionDie) DieWith(fn func(d *WebhookConversionDie)) *WebhookConversionDie {
+	nd := WebhookConversionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *WebhookConversionDie) DeepCopy() *WebhookConversionDie {
 	r := *d.r.DeepCopy()
@@ -1873,6 +1936,13 @@ func (d *WebhookClientConfigDie) DieStampAt(jp string, fn interface{}) *WebhookC
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *WebhookClientConfigDie) DieWith(fn func(d *WebhookClientConfigDie)) *WebhookClientConfigDie {
+	nd := WebhookClientConfigBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2062,6 +2132,13 @@ func (d *ServiceReferenceDie) DieStampAt(jp string, fn interface{}) *ServiceRefe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServiceReferenceDie) DieWith(fn func(d *ServiceReferenceDie)) *ServiceReferenceDie {
+	nd := ServiceReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ServiceReferenceDie) DeepCopy() *ServiceReferenceDie {
 	r := *d.r.DeepCopy()
@@ -2244,6 +2321,13 @@ func (d *CustomResourceDefinitionStatusDie) DieStampAt(jp string, fn interface{}
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CustomResourceDefinitionStatusDie) DieWith(fn func(d *CustomResourceDefinitionStatusDie)) *CustomResourceDefinitionStatusDie {
+	nd := CustomResourceDefinitionStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CustomResourceDefinitionStatusDie) DeepCopy() *CustomResourceDefinitionStatusDie {
 	r := *d.r.DeepCopy()
@@ -2417,6 +2501,13 @@ func (d *CustomResourceDefinitionNamesDie) DieStampAt(jp string, fn interface{})
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CustomResourceDefinitionNamesDie) DieWith(fn func(d *CustomResourceDefinitionNamesDie)) *CustomResourceDefinitionNamesDie {
+	nd := CustomResourceDefinitionNamesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/apiregistration/v1/zz_generated.die.go
+++ b/apis/apiregistration/v1/zz_generated.die.go
@@ -195,6 +195,13 @@ func (d *APIServiceDie) DieStampAt(jp string, fn interface{}) *APIServiceDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *APIServiceDie) DieWith(fn func(d *APIServiceDie)) *APIServiceDie {
+	nd := APIServiceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *APIServiceDie) DeepCopy() *APIServiceDie {
 	r := *d.r.DeepCopy()
@@ -433,6 +440,13 @@ func (d *APIServiceSpecDie) DieStampAt(jp string, fn interface{}) *APIServiceSpe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *APIServiceSpecDie) DieWith(fn func(d *APIServiceSpecDie)) *APIServiceSpecDie {
+	nd := APIServiceSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *APIServiceSpecDie) DeepCopy() *APIServiceSpecDie {
 	r := *d.r.DeepCopy()
@@ -636,6 +650,13 @@ func (d *ServiceReferenceDie) DieStampAt(jp string, fn interface{}) *ServiceRefe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServiceReferenceDie) DieWith(fn func(d *ServiceReferenceDie)) *ServiceReferenceDie {
+	nd := ServiceReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ServiceReferenceDie) DeepCopy() *ServiceReferenceDie {
 	r := *d.r.DeepCopy()
@@ -809,6 +830,13 @@ func (d *APIServiceStatusDie) DieStampAt(jp string, fn interface{}) *APIServiceS
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *APIServiceStatusDie) DieWith(fn func(d *APIServiceStatusDie)) *APIServiceStatusDie {
+	nd := APIServiceStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/apiserver/flowcontrol/v1beta1/zz_generated.die.go
+++ b/apis/apiserver/flowcontrol/v1beta1/zz_generated.die.go
@@ -195,6 +195,13 @@ func (d *FlowSchemaDie) DieStampAt(jp string, fn interface{}) *FlowSchemaDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *FlowSchemaDie) DieWith(fn func(d *FlowSchemaDie)) *FlowSchemaDie {
+	nd := FlowSchemaBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *FlowSchemaDie) DeepCopy() *FlowSchemaDie {
 	r := *d.r.DeepCopy()
@@ -433,6 +440,13 @@ func (d *FlowSchemaSpecDie) DieStampAt(jp string, fn interface{}) *FlowSchemaSpe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *FlowSchemaSpecDie) DieWith(fn func(d *FlowSchemaSpecDie)) *FlowSchemaSpecDie {
+	nd := FlowSchemaSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *FlowSchemaSpecDie) DeepCopy() *FlowSchemaSpecDie {
 	r := *d.r.DeepCopy()
@@ -615,6 +629,13 @@ func (d *FlowSchemaStatusDie) DieStampAt(jp string, fn interface{}) *FlowSchemaS
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *FlowSchemaStatusDie) DieWith(fn func(d *FlowSchemaStatusDie)) *FlowSchemaStatusDie {
+	nd := FlowSchemaStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *FlowSchemaStatusDie) DeepCopy() *FlowSchemaStatusDie {
 	r := *d.r.DeepCopy()
@@ -774,6 +795,13 @@ func (d *PriorityLevelConfigurationReferenceDie) DieStampAt(jp string, fn interf
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PriorityLevelConfigurationReferenceDie) DieWith(fn func(d *PriorityLevelConfigurationReferenceDie)) *PriorityLevelConfigurationReferenceDie {
+	nd := PriorityLevelConfigurationReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -937,6 +965,13 @@ func (d *FlowDistinguisherMethodDie) DieStampAt(jp string, fn interface{}) *Flow
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *FlowDistinguisherMethodDie) DieWith(fn func(d *FlowDistinguisherMethodDie)) *FlowDistinguisherMethodDie {
+	nd := FlowDistinguisherMethodBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *FlowDistinguisherMethodDie) DeepCopy() *FlowDistinguisherMethodDie {
 	r := *d.r.DeepCopy()
@@ -1096,6 +1131,13 @@ func (d *PolicyRulesWithSubjectsDie) DieStampAt(jp string, fn interface{}) *Poli
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PolicyRulesWithSubjectsDie) DieWith(fn func(d *PolicyRulesWithSubjectsDie)) *PolicyRulesWithSubjectsDie {
+	nd := PolicyRulesWithSubjectsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1271,6 +1313,13 @@ func (d *SubjectDie) DieStampAt(jp string, fn interface{}) *SubjectDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SubjectDie) DieWith(fn func(d *SubjectDie)) *SubjectDie {
+	nd := SubjectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1455,6 +1504,13 @@ func (d *UserSubjectDie) DieStampAt(jp string, fn interface{}) *UserSubjectDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *UserSubjectDie) DieWith(fn func(d *UserSubjectDie)) *UserSubjectDie {
+	nd := UserSubjectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *UserSubjectDie) DeepCopy() *UserSubjectDie {
 	r := *d.r.DeepCopy()
@@ -1616,6 +1672,13 @@ func (d *GroupSubjectDie) DieStampAt(jp string, fn interface{}) *GroupSubjectDie
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GroupSubjectDie) DieWith(fn func(d *GroupSubjectDie)) *GroupSubjectDie {
+	nd := GroupSubjectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *GroupSubjectDie) DeepCopy() *GroupSubjectDie {
 	r := *d.r.DeepCopy()
@@ -1775,6 +1838,13 @@ func (d *ServiceAccountSubjectDie) DieStampAt(jp string, fn interface{}) *Servic
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServiceAccountSubjectDie) DieWith(fn func(d *ServiceAccountSubjectDie)) *ServiceAccountSubjectDie {
+	nd := ServiceAccountSubjectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1943,6 +2013,13 @@ func (d *ResourcePolicyRuleDie) DieStampAt(jp string, fn interface{}) *ResourceP
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ResourcePolicyRuleDie) DieWith(fn func(d *ResourcePolicyRuleDie)) *ResourcePolicyRuleDie {
+	nd := ResourcePolicyRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2134,6 +2211,13 @@ func (d *NonResourcePolicyRuleDie) DieStampAt(jp string, fn interface{}) *NonRes
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NonResourcePolicyRuleDie) DieWith(fn func(d *NonResourcePolicyRuleDie)) *NonResourcePolicyRuleDie {
+	nd := NonResourcePolicyRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NonResourcePolicyRuleDie) DeepCopy() *NonResourcePolicyRuleDie {
 	r := *d.r.DeepCopy()
@@ -2315,6 +2399,13 @@ func (d *PriorityLevelConfigurationDie) DieStampAt(jp string, fn interface{}) *P
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PriorityLevelConfigurationDie) DieWith(fn func(d *PriorityLevelConfigurationDie)) *PriorityLevelConfigurationDie {
+	nd := PriorityLevelConfigurationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2555,6 +2646,13 @@ func (d *PriorityLevelConfigurationSpecDie) DieStampAt(jp string, fn interface{}
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PriorityLevelConfigurationSpecDie) DieWith(fn func(d *PriorityLevelConfigurationSpecDie)) *PriorityLevelConfigurationSpecDie {
+	nd := PriorityLevelConfigurationSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PriorityLevelConfigurationSpecDie) DeepCopy() *PriorityLevelConfigurationSpecDie {
 	r := *d.r.DeepCopy()
@@ -2721,6 +2819,13 @@ func (d *LimitedPriorityLevelConfigurationDie) DieStampAt(jp string, fn interfac
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LimitedPriorityLevelConfigurationDie) DieWith(fn func(d *LimitedPriorityLevelConfigurationDie)) *LimitedPriorityLevelConfigurationDie {
+	nd := LimitedPriorityLevelConfigurationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2915,6 +3020,13 @@ func (d *LimitResponseDie) DieStampAt(jp string, fn interface{}) *LimitResponseD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LimitResponseDie) DieWith(fn func(d *LimitResponseDie)) *LimitResponseDie {
+	nd := LimitResponseBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *LimitResponseDie) DeepCopy() *LimitResponseDie {
 	r := *d.r.DeepCopy()
@@ -3081,6 +3193,13 @@ func (d *QueuingConfigurationDie) DieStampAt(jp string, fn interface{}) *Queuing
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *QueuingConfigurationDie) DieWith(fn func(d *QueuingConfigurationDie)) *QueuingConfigurationDie {
+	nd := QueuingConfigurationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -3256,6 +3375,13 @@ func (d *PriorityLevelConfigurationStatusDie) DieStampAt(jp string, fn interface
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PriorityLevelConfigurationStatusDie) DieWith(fn func(d *PriorityLevelConfigurationStatusDie)) *PriorityLevelConfigurationStatusDie {
+	nd := PriorityLevelConfigurationStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/apps/v1/zz_generated.die.go
+++ b/apis/apps/v1/zz_generated.die.go
@@ -198,6 +198,13 @@ func (d *ControllerRevisionDie) DieStampAt(jp string, fn interface{}) *Controlle
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ControllerRevisionDie) DieWith(fn func(d *ControllerRevisionDie)) *ControllerRevisionDie {
+	nd := ControllerRevisionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ControllerRevisionDie) DeepCopy() *ControllerRevisionDie {
 	r := *d.r.DeepCopy()
@@ -431,6 +438,13 @@ func (d *DaemonSetDie) DieStampAt(jp string, fn interface{}) *DaemonSetDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DaemonSetDie) DieWith(fn func(d *DaemonSetDie)) *DaemonSetDie {
+	nd := DaemonSetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -671,6 +685,13 @@ func (d *DaemonSetSpecDie) DieStampAt(jp string, fn interface{}) *DaemonSetSpecD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DaemonSetSpecDie) DieWith(fn func(d *DaemonSetSpecDie)) *DaemonSetSpecDie {
+	nd := DaemonSetSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *DaemonSetSpecDie) DeepCopy() *DaemonSetSpecDie {
 	r := *d.r.DeepCopy()
@@ -860,6 +881,13 @@ func (d *DaemonSetUpdateStrategyDie) DieStampAt(jp string, fn interface{}) *Daem
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DaemonSetUpdateStrategyDie) DieWith(fn func(d *DaemonSetUpdateStrategyDie)) *DaemonSetUpdateStrategyDie {
+	nd := DaemonSetUpdateStrategyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *DaemonSetUpdateStrategyDie) DeepCopy() *DaemonSetUpdateStrategyDie {
 	r := *d.r.DeepCopy()
@@ -1026,6 +1054,13 @@ func (d *RollingUpdateDaemonSetDie) DieStampAt(jp string, fn interface{}) *Rolli
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RollingUpdateDaemonSetDie) DieWith(fn func(d *RollingUpdateDaemonSetDie)) *RollingUpdateDaemonSetDie {
+	nd := RollingUpdateDaemonSetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1222,6 +1257,13 @@ func (d *DaemonSetStatusDie) DieStampAt(jp string, fn interface{}) *DaemonSetSta
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DaemonSetStatusDie) DieWith(fn func(d *DaemonSetStatusDie)) *DaemonSetStatusDie {
+	nd := DaemonSetStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1463,6 +1505,13 @@ func (d *DeploymentDie) DieStampAt(jp string, fn interface{}) *DeploymentDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DeploymentDie) DieWith(fn func(d *DeploymentDie)) *DeploymentDie {
+	nd := DeploymentBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *DeploymentDie) DeepCopy() *DeploymentDie {
 	r := *d.r.DeepCopy()
@@ -1701,6 +1750,13 @@ func (d *DeploymentSpecDie) DieStampAt(jp string, fn interface{}) *DeploymentSpe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DeploymentSpecDie) DieWith(fn func(d *DeploymentSpecDie)) *DeploymentSpecDie {
+	nd := DeploymentSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *DeploymentSpecDie) DeepCopy() *DeploymentSpecDie {
 	r := *d.r.DeepCopy()
@@ -1911,6 +1967,13 @@ func (d *DeploymentStrategyDie) DieStampAt(jp string, fn interface{}) *Deploymen
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DeploymentStrategyDie) DieWith(fn func(d *DeploymentStrategyDie)) *DeploymentStrategyDie {
+	nd := DeploymentStrategyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *DeploymentStrategyDie) DeepCopy() *DeploymentStrategyDie {
 	r := *d.r.DeepCopy()
@@ -2077,6 +2140,13 @@ func (d *RollingUpdateDeploymentDie) DieStampAt(jp string, fn interface{}) *Roll
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RollingUpdateDeploymentDie) DieWith(fn func(d *RollingUpdateDeploymentDie)) *RollingUpdateDeploymentDie {
+	nd := RollingUpdateDeploymentBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2273,6 +2343,13 @@ func (d *DeploymentStatusDie) DieStampAt(jp string, fn interface{}) *DeploymentS
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DeploymentStatusDie) DieWith(fn func(d *DeploymentStatusDie)) *DeploymentStatusDie {
+	nd := DeploymentStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2498,6 +2575,13 @@ func (d *ReplicaSetDie) DieStampAt(jp string, fn interface{}) *ReplicaSetDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ReplicaSetDie) DieWith(fn func(d *ReplicaSetDie)) *ReplicaSetDie {
+	nd := ReplicaSetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2738,6 +2822,13 @@ func (d *ReplicaSetSpecDie) DieStampAt(jp string, fn interface{}) *ReplicaSetSpe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ReplicaSetSpecDie) DieWith(fn func(d *ReplicaSetSpecDie)) *ReplicaSetSpecDie {
+	nd := ReplicaSetSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ReplicaSetSpecDie) DeepCopy() *ReplicaSetSpecDie {
 	r := *d.r.DeepCopy()
@@ -2918,6 +3009,13 @@ func (d *ReplicaSetStatusDie) DieStampAt(jp string, fn interface{}) *ReplicaSetS
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ReplicaSetStatusDie) DieWith(fn func(d *ReplicaSetStatusDie)) *ReplicaSetStatusDie {
+	nd := ReplicaSetStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -3129,6 +3227,13 @@ func (d *StatefulSetDie) DieStampAt(jp string, fn interface{}) *StatefulSetDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StatefulSetDie) DieWith(fn func(d *StatefulSetDie)) *StatefulSetDie {
+	nd := StatefulSetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -3369,6 +3474,13 @@ func (d *StatefulSetSpecDie) DieStampAt(jp string, fn interface{}) *StatefulSetS
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StatefulSetSpecDie) DieWith(fn func(d *StatefulSetSpecDie)) *StatefulSetSpecDie {
+	nd := StatefulSetSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *StatefulSetSpecDie) DeepCopy() *StatefulSetSpecDie {
 	r := *d.r.DeepCopy()
@@ -3600,6 +3712,13 @@ func (d *StatefulSetUpdateStrategyDie) DieStampAt(jp string, fn interface{}) *St
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StatefulSetUpdateStrategyDie) DieWith(fn func(d *StatefulSetUpdateStrategyDie)) *StatefulSetUpdateStrategyDie {
+	nd := StatefulSetUpdateStrategyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *StatefulSetUpdateStrategyDie) DeepCopy() *StatefulSetUpdateStrategyDie {
 	r := *d.r.DeepCopy()
@@ -3766,6 +3885,13 @@ func (d *RollingUpdateStatefulSetStrategyDie) DieStampAt(jp string, fn interface
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RollingUpdateStatefulSetStrategyDie) DieWith(fn func(d *RollingUpdateStatefulSetStrategyDie)) *RollingUpdateStatefulSetStrategyDie {
+	nd := RollingUpdateStatefulSetStrategyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -3950,6 +4076,13 @@ func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieStampAt(jp strin
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieWith(fn func(d *StatefulSetPersistentVolumeClaimRetentionPolicyDie)) *StatefulSetPersistentVolumeClaimRetentionPolicyDie {
+	nd := StatefulSetPersistentVolumeClaimRetentionPolicyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DeepCopy() *StatefulSetPersistentVolumeClaimRetentionPolicyDie {
 	r := *d.r.DeepCopy()
@@ -4118,6 +4251,13 @@ func (d *StatefulSetOrdinalsDie) DieStampAt(jp string, fn interface{}) *Stateful
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StatefulSetOrdinalsDie) DieWith(fn func(d *StatefulSetOrdinalsDie)) *StatefulSetOrdinalsDie {
+	nd := StatefulSetOrdinalsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *StatefulSetOrdinalsDie) DeepCopy() *StatefulSetOrdinalsDie {
 	r := *d.r.DeepCopy()
@@ -4277,6 +4417,13 @@ func (d *StatefulSetStatusDie) DieStampAt(jp string, fn interface{}) *StatefulSe
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StatefulSetStatusDie) DieWith(fn func(d *StatefulSetStatusDie)) *StatefulSetStatusDie {
+	nd := StatefulSetStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/authentication/v1/zz_generated.die.go
+++ b/apis/authentication/v1/zz_generated.die.go
@@ -197,6 +197,13 @@ func (d *TokenReviewDie) DieStampAt(jp string, fn interface{}) *TokenReviewDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TokenReviewDie) DieWith(fn func(d *TokenReviewDie)) *TokenReviewDie {
+	nd := TokenReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *TokenReviewDie) DeepCopy() *TokenReviewDie {
 	r := *d.r.DeepCopy()
@@ -417,6 +424,13 @@ func (d *TokenRequestSpecDie) DieStampAt(jp string, fn interface{}) *TokenReques
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TokenRequestSpecDie) DieWith(fn func(d *TokenRequestSpecDie)) *TokenRequestSpecDie {
+	nd := TokenRequestSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *TokenRequestSpecDie) DeepCopy() *TokenRequestSpecDie {
 	r := *d.r.DeepCopy()
@@ -590,6 +604,13 @@ func (d *BoundObjectReferenceDie) DieStampAt(jp string, fn interface{}) *BoundOb
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *BoundObjectReferenceDie) DieWith(fn func(d *BoundObjectReferenceDie)) *BoundObjectReferenceDie {
+	nd := BoundObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -774,6 +795,13 @@ func (d *TokenRequestStatusDie) DieStampAt(jp string, fn interface{}) *TokenRequ
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TokenRequestStatusDie) DieWith(fn func(d *TokenRequestStatusDie)) *TokenRequestStatusDie {
+	nd := TokenRequestStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *TokenRequestStatusDie) DeepCopy() *TokenRequestStatusDie {
 	r := *d.r.DeepCopy()
@@ -940,6 +968,13 @@ func (d *UserInfoDie) DieStampAt(jp string, fn interface{}) *UserInfoDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *UserInfoDie) DieWith(fn func(d *UserInfoDie)) *UserInfoDie {
+	nd := UserInfoBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/authorization/rbac/v1/zz_generated.die.go
+++ b/apis/authorization/rbac/v1/zz_generated.die.go
@@ -196,6 +196,13 @@ func (d *ClusterRoleDie) DieStampAt(jp string, fn interface{}) *ClusterRoleDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ClusterRoleDie) DieWith(fn func(d *ClusterRoleDie)) *ClusterRoleDie {
+	nd := ClusterRoleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ClusterRoleDie) DeepCopy() *ClusterRoleDie {
 	r := *d.r.DeepCopy()
@@ -416,6 +423,13 @@ func (d *AggregationRuleDie) DieStampAt(jp string, fn interface{}) *AggregationR
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AggregationRuleDie) DieWith(fn func(d *AggregationRuleDie)) *AggregationRuleDie {
+	nd := AggregationRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *AggregationRuleDie) DeepCopy() *AggregationRuleDie {
 	r := *d.r.DeepCopy()
@@ -590,6 +604,13 @@ func (d *ClusterRoleBindingDie) DieStampAt(jp string, fn interface{}) *ClusterRo
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ClusterRoleBindingDie) DieWith(fn func(d *ClusterRoleBindingDie)) *ClusterRoleBindingDie {
+	nd := ClusterRoleBindingBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -827,6 +848,13 @@ func (d *RoleDie) DieStampAt(jp string, fn interface{}) *RoleDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RoleDie) DieWith(fn func(d *RoleDie)) *RoleDie {
+	nd := RoleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *RoleDie) DeepCopy() *RoleDie {
 	r := *d.r.DeepCopy()
@@ -1040,6 +1068,13 @@ func (d *PolicyRuleDie) DieStampAt(jp string, fn interface{}) *PolicyRuleDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PolicyRuleDie) DieWith(fn func(d *PolicyRuleDie)) *PolicyRuleDie {
+	nd := PolicyRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PolicyRuleDie) DeepCopy() *PolicyRuleDie {
 	r := *d.r.DeepCopy()
@@ -1242,6 +1277,13 @@ func (d *RoleBindingDie) DieStampAt(jp string, fn interface{}) *RoleBindingDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RoleBindingDie) DieWith(fn func(d *RoleBindingDie)) *RoleBindingDie {
+	nd := RoleBindingBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1464,6 +1506,13 @@ func (d *SubjectDie) DieStampAt(jp string, fn interface{}) *SubjectDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SubjectDie) DieWith(fn func(d *SubjectDie)) *SubjectDie {
+	nd := SubjectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SubjectDie) DeepCopy() *SubjectDie {
 	r := *d.r.DeepCopy()
@@ -1644,6 +1693,13 @@ func (d *RoleRefDie) DieStampAt(jp string, fn interface{}) *RoleRefDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RoleRefDie) DieWith(fn func(d *RoleRefDie)) *RoleRefDie {
+	nd := RoleRefBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/authorization/v1/zz_generated.die.go
+++ b/apis/authorization/v1/zz_generated.die.go
@@ -195,6 +195,13 @@ func (d *LocalSubjectAccessReviewDie) DieStampAt(jp string, fn interface{}) *Loc
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LocalSubjectAccessReviewDie) DieWith(fn func(d *LocalSubjectAccessReviewDie)) *LocalSubjectAccessReviewDie {
+	nd := LocalSubjectAccessReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *LocalSubjectAccessReviewDie) DeepCopy() *LocalSubjectAccessReviewDie {
 	r := *d.r.DeepCopy()
@@ -428,6 +435,13 @@ func (d *SelfSubjectAccessReviewDie) DieStampAt(jp string, fn interface{}) *Self
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SelfSubjectAccessReviewDie) DieWith(fn func(d *SelfSubjectAccessReviewDie)) *SelfSubjectAccessReviewDie {
+	nd := SelfSubjectAccessReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -668,6 +682,13 @@ func (d *SelfSubjectAccessReviewSpecDie) DieStampAt(jp string, fn interface{}) *
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SelfSubjectAccessReviewSpecDie) DieWith(fn func(d *SelfSubjectAccessReviewSpecDie)) *SelfSubjectAccessReviewSpecDie {
+	nd := SelfSubjectAccessReviewSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SelfSubjectAccessReviewSpecDie) DeepCopy() *SelfSubjectAccessReviewSpecDie {
 	r := *d.r.DeepCopy()
@@ -849,6 +870,13 @@ func (d *SelfSubjectRulesReviewDie) DieStampAt(jp string, fn interface{}) *SelfS
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SelfSubjectRulesReviewDie) DieWith(fn func(d *SelfSubjectRulesReviewDie)) *SelfSubjectRulesReviewDie {
+	nd := SelfSubjectRulesReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1089,6 +1117,13 @@ func (d *SelfSubjectRulesReviewSpecDie) DieStampAt(jp string, fn interface{}) *S
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SelfSubjectRulesReviewSpecDie) DieWith(fn func(d *SelfSubjectRulesReviewSpecDie)) *SelfSubjectRulesReviewSpecDie {
+	nd := SelfSubjectRulesReviewSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SelfSubjectRulesReviewSpecDie) DeepCopy() *SelfSubjectRulesReviewSpecDie {
 	r := *d.r.DeepCopy()
@@ -1248,6 +1283,13 @@ func (d *SubjectRulesReviewStatusDie) DieStampAt(jp string, fn interface{}) *Sub
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SubjectRulesReviewStatusDie) DieWith(fn func(d *SubjectRulesReviewStatusDie)) *SubjectRulesReviewStatusDie {
+	nd := SubjectRulesReviewStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1432,6 +1474,13 @@ func (d *ResourceRuleDie) DieStampAt(jp string, fn interface{}) *ResourceRuleDie
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ResourceRuleDie) DieWith(fn func(d *ResourceRuleDie)) *ResourceRuleDie {
+	nd := ResourceRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ResourceRuleDie) DeepCopy() *ResourceRuleDie {
 	r := *d.r.DeepCopy()
@@ -1612,6 +1661,13 @@ func (d *NonResourceRuleDie) DieStampAt(jp string, fn interface{}) *NonResourceR
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NonResourceRuleDie) DieWith(fn func(d *NonResourceRuleDie)) *NonResourceRuleDie {
+	nd := NonResourceRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1795,6 +1851,13 @@ func (d *SubjectAccessReviewDie) DieStampAt(jp string, fn interface{}) *SubjectA
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SubjectAccessReviewDie) DieWith(fn func(d *SubjectAccessReviewDie)) *SubjectAccessReviewDie {
+	nd := SubjectAccessReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2035,6 +2098,13 @@ func (d *SubjectAccessReviewSpecDie) DieStampAt(jp string, fn interface{}) *Subj
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SubjectAccessReviewSpecDie) DieWith(fn func(d *SubjectAccessReviewSpecDie)) *SubjectAccessReviewSpecDie {
+	nd := SubjectAccessReviewSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SubjectAccessReviewSpecDie) DeepCopy() *SubjectAccessReviewSpecDie {
 	r := *d.r.DeepCopy()
@@ -2222,6 +2292,13 @@ func (d *ResourceAttributesDie) DieStampAt(jp string, fn interface{}) *ResourceA
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ResourceAttributesDie) DieWith(fn func(d *ResourceAttributesDie)) *ResourceAttributesDie {
+	nd := ResourceAttributesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2427,6 +2504,13 @@ func (d *NonResourceAttributesDie) DieStampAt(jp string, fn interface{}) *NonRes
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NonResourceAttributesDie) DieWith(fn func(d *NonResourceAttributesDie)) *NonResourceAttributesDie {
+	nd := NonResourceAttributesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NonResourceAttributesDie) DeepCopy() *NonResourceAttributesDie {
 	r := *d.r.DeepCopy()
@@ -2593,6 +2677,13 @@ func (d *SubjectAccessReviewStatusDie) DieStampAt(jp string, fn interface{}) *Su
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SubjectAccessReviewStatusDie) DieWith(fn func(d *SubjectAccessReviewStatusDie)) *SubjectAccessReviewStatusDie {
+	nd := SubjectAccessReviewStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/autoscaling/v1/zz_generated.die.go
+++ b/apis/autoscaling/v1/zz_generated.die.go
@@ -196,6 +196,13 @@ func (d *HorizontalPodAutoscalerDie) DieStampAt(jp string, fn interface{}) *Hori
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *HorizontalPodAutoscalerDie) DieWith(fn func(d *HorizontalPodAutoscalerDie)) *HorizontalPodAutoscalerDie {
+	nd := HorizontalPodAutoscalerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *HorizontalPodAutoscalerDie) DeepCopy() *HorizontalPodAutoscalerDie {
 	r := *d.r.DeepCopy()
@@ -434,6 +441,13 @@ func (d *HorizontalPodAutoscalerSpecDie) DieStampAt(jp string, fn interface{}) *
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *HorizontalPodAutoscalerSpecDie) DieWith(fn func(d *HorizontalPodAutoscalerSpecDie)) *HorizontalPodAutoscalerSpecDie {
+	nd := HorizontalPodAutoscalerSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *HorizontalPodAutoscalerSpecDie) DeepCopy() *HorizontalPodAutoscalerSpecDie {
 	r := *d.r.DeepCopy()
@@ -616,6 +630,13 @@ func (d *CrossVersionObjectReferenceDie) DieStampAt(jp string, fn interface{}) *
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CrossVersionObjectReferenceDie) DieWith(fn func(d *CrossVersionObjectReferenceDie)) *CrossVersionObjectReferenceDie {
+	nd := CrossVersionObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CrossVersionObjectReferenceDie) DeepCopy() *CrossVersionObjectReferenceDie {
 	r := *d.r.DeepCopy()
@@ -789,6 +810,13 @@ func (d *HorizontalPodAutoscalerStatusDie) DieStampAt(jp string, fn interface{})
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *HorizontalPodAutoscalerStatusDie) DieWith(fn func(d *HorizontalPodAutoscalerStatusDie)) *HorizontalPodAutoscalerStatusDie {
+	nd := HorizontalPodAutoscalerStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/batch/v1/zz_generated.die.go
+++ b/apis/batch/v1/zz_generated.die.go
@@ -198,6 +198,13 @@ func (d *CronJobDie) DieStampAt(jp string, fn interface{}) *CronJobDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CronJobDie) DieWith(fn func(d *CronJobDie)) *CronJobDie {
+	nd := CronJobBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CronJobDie) DeepCopy() *CronJobDie {
 	r := *d.r.DeepCopy()
@@ -436,6 +443,13 @@ func (d *CronJobSpecDie) DieStampAt(jp string, fn interface{}) *CronJobSpecDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CronJobSpecDie) DieWith(fn func(d *CronJobSpecDie)) *CronJobSpecDie {
+	nd := CronJobSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CronJobSpecDie) DeepCopy() *CronJobSpecDie {
 	r := *d.r.DeepCopy()
@@ -648,6 +662,13 @@ func (d *CronJobStatusDie) DieStampAt(jp string, fn interface{}) *CronJobStatusD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CronJobStatusDie) DieWith(fn func(d *CronJobStatusDie)) *CronJobStatusDie {
+	nd := CronJobStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CronJobStatusDie) DeepCopy() *CronJobStatusDie {
 	r := *d.r.DeepCopy()
@@ -836,6 +857,13 @@ func (d *JobDie) DieStampAt(jp string, fn interface{}) *JobDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *JobDie) DieWith(fn func(d *JobDie)) *JobDie {
+	nd := JobBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1074,6 +1102,13 @@ func (d *JobSpecDie) DieStampAt(jp string, fn interface{}) *JobSpecDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *JobSpecDie) DieWith(fn func(d *JobSpecDie)) *JobSpecDie {
+	nd := JobSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1315,6 +1350,13 @@ func (d *PodFailurePolicyDie) DieStampAt(jp string, fn interface{}) *PodFailureP
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodFailurePolicyDie) DieWith(fn func(d *PodFailurePolicyDie)) *PodFailurePolicyDie {
+	nd := PodFailurePolicyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodFailurePolicyDie) DeepCopy() *PodFailurePolicyDie {
 	r := *d.r.DeepCopy()
@@ -1474,6 +1516,13 @@ func (d *PodFailurePolicyRuleDie) DieStampAt(jp string, fn interface{}) *PodFail
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodFailurePolicyRuleDie) DieWith(fn func(d *PodFailurePolicyRuleDie)) *PodFailurePolicyRuleDie {
+	nd := PodFailurePolicyRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1653,6 +1702,13 @@ func (d *PodFailurePolicyOnExitCodesRequirementDie) DieStampAt(jp string, fn int
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodFailurePolicyOnExitCodesRequirementDie) DieWith(fn func(d *PodFailurePolicyOnExitCodesRequirementDie)) *PodFailurePolicyOnExitCodesRequirementDie {
+	nd := PodFailurePolicyOnExitCodesRequirementBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodFailurePolicyOnExitCodesRequirementDie) DeepCopy() *PodFailurePolicyOnExitCodesRequirementDie {
 	r := *d.r.DeepCopy()
@@ -1830,6 +1886,13 @@ func (d *PodFailurePolicyOnPodConditionsPatternDie) DieStampAt(jp string, fn int
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodFailurePolicyOnPodConditionsPatternDie) DieWith(fn func(d *PodFailurePolicyOnPodConditionsPatternDie)) *PodFailurePolicyOnPodConditionsPatternDie {
+	nd := PodFailurePolicyOnPodConditionsPatternBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodFailurePolicyOnPodConditionsPatternDie) DeepCopy() *PodFailurePolicyOnPodConditionsPatternDie {
 	r := *d.r.DeepCopy()
@@ -1996,6 +2059,13 @@ func (d *JobStatusDie) DieStampAt(jp string, fn interface{}) *JobStatusDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *JobStatusDie) DieWith(fn func(d *JobStatusDie)) *JobStatusDie {
+	nd := JobStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2221,6 +2291,13 @@ func (d *UncountedTerminatedPodsDie) DieStampAt(jp string, fn interface{}) *Unco
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *UncountedTerminatedPodsDie) DieWith(fn func(d *UncountedTerminatedPodsDie)) *UncountedTerminatedPodsDie {
+	nd := UncountedTerminatedPodsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/certificates/v1/zz_generated.die.go
+++ b/apis/certificates/v1/zz_generated.die.go
@@ -195,6 +195,13 @@ func (d *CertificateSigningRequestDie) DieStampAt(jp string, fn interface{}) *Ce
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CertificateSigningRequestDie) DieWith(fn func(d *CertificateSigningRequestDie)) *CertificateSigningRequestDie {
+	nd := CertificateSigningRequestBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CertificateSigningRequestDie) DeepCopy() *CertificateSigningRequestDie {
 	r := *d.r.DeepCopy()
@@ -433,6 +440,13 @@ func (d *CertificateSigningRequestSpecDie) DieStampAt(jp string, fn interface{})
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CertificateSigningRequestSpecDie) DieWith(fn func(d *CertificateSigningRequestSpecDie)) *CertificateSigningRequestSpecDie {
+	nd := CertificateSigningRequestSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CertificateSigningRequestSpecDie) DeepCopy() *CertificateSigningRequestSpecDie {
 	r := *d.r.DeepCopy()
@@ -656,6 +670,13 @@ func (d *CertificateSigningRequestStatusDie) DieStampAt(jp string, fn interface{
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CertificateSigningRequestStatusDie) DieWith(fn func(d *CertificateSigningRequestStatusDie)) *CertificateSigningRequestStatusDie {
+	nd := CertificateSigningRequestStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/coordination/v1/zz_generated.die.go
+++ b/apis/coordination/v1/zz_generated.die.go
@@ -196,6 +196,13 @@ func (d *LeaseDie) DieStampAt(jp string, fn interface{}) *LeaseDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LeaseDie) DieWith(fn func(d *LeaseDie)) *LeaseDie {
+	nd := LeaseBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *LeaseDie) DeepCopy() *LeaseDie {
 	r := *d.r.DeepCopy()
@@ -416,6 +423,13 @@ func (d *LeaseSpecDie) DieStampAt(jp string, fn interface{}) *LeaseSpecDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LeaseSpecDie) DieWith(fn func(d *LeaseSpecDie)) *LeaseSpecDie {
+	nd := LeaseSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/core/v1/pod_test.go
+++ b/apis/core/v1/pod_test.go
@@ -371,6 +371,20 @@ func TestPod(t *testing.T) {
 			},
 		},
 		{
+			name: "with",
+			die: diecorev1.PodBlank.
+				DieWith(func(d *diecorev1.PodDie) {
+					d.APIVersion("v1")
+					d.Kind("Pod")
+				}),
+			expected: corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+			},
+		},
+		{
 			name:         "load from yaml",
 			yamlFilePath: "testdata/pod.yaml",
 			expected: corev1.Pod{

--- a/apis/core/v1/zz_generated.die.go
+++ b/apis/core/v1/zz_generated.die.go
@@ -199,6 +199,13 @@ func (d *BindingDie) DieStampAt(jp string, fn interface{}) *BindingDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *BindingDie) DieWith(fn func(d *BindingDie)) *BindingDie {
+	nd := BindingBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *BindingDie) DeepCopy() *BindingDie {
 	r := *d.r.DeepCopy()
@@ -412,6 +419,13 @@ func (d *ObjectReferenceDie) DieStampAt(jp string, fn interface{}) *ObjectRefere
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ObjectReferenceDie) DieWith(fn func(d *ObjectReferenceDie)) *ObjectReferenceDie {
+	nd := ObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ObjectReferenceDie) DeepCopy() *ObjectReferenceDie {
 	r := *d.r.DeepCopy()
@@ -615,6 +629,13 @@ func (d *LocalObjectReferenceDie) DieStampAt(jp string, fn interface{}) *LocalOb
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LocalObjectReferenceDie) DieWith(fn func(d *LocalObjectReferenceDie)) *LocalObjectReferenceDie {
+	nd := LocalObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *LocalObjectReferenceDie) DeepCopy() *LocalObjectReferenceDie {
 	r := *d.r.DeepCopy()
@@ -774,6 +795,13 @@ func (d *TypedLocalObjectReferenceDie) DieStampAt(jp string, fn interface{}) *Ty
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TypedLocalObjectReferenceDie) DieWith(fn func(d *TypedLocalObjectReferenceDie)) *TypedLocalObjectReferenceDie {
+	nd := TypedLocalObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -949,6 +977,13 @@ func (d *TypedObjectReferenceDie) DieStampAt(jp string, fn interface{}) *TypedOb
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TypedObjectReferenceDie) DieWith(fn func(d *TypedObjectReferenceDie)) *TypedObjectReferenceDie {
+	nd := TypedObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1133,6 +1168,13 @@ func (d *SecretReferenceDie) DieStampAt(jp string, fn interface{}) *SecretRefere
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SecretReferenceDie) DieWith(fn func(d *SecretReferenceDie)) *SecretReferenceDie {
+	nd := SecretReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SecretReferenceDie) DeepCopy() *SecretReferenceDie {
 	r := *d.r.DeepCopy()
@@ -1301,6 +1343,13 @@ func (d *TopologySelectorTermDie) DieStampAt(jp string, fn interface{}) *Topolog
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TopologySelectorTermDie) DieWith(fn func(d *TopologySelectorTermDie)) *TopologySelectorTermDie {
+	nd := TopologySelectorTermBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *TopologySelectorTermDie) DeepCopy() *TopologySelectorTermDie {
 	r := *d.r.DeepCopy()
@@ -1460,6 +1509,13 @@ func (d *TopologySelectorLabelRequirementDie) DieStampAt(jp string, fn interface
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TopologySelectorLabelRequirementDie) DieWith(fn func(d *TopologySelectorLabelRequirementDie)) *TopologySelectorLabelRequirementDie {
+	nd := TopologySelectorLabelRequirementBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1643,6 +1699,13 @@ func (d *ComponentStatusDie) DieStampAt(jp string, fn interface{}) *ComponentSta
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ComponentStatusDie) DieWith(fn func(d *ComponentStatusDie)) *ComponentStatusDie {
+	nd := ComponentStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1873,6 +1936,13 @@ func (d *ConfigMapDie) DieStampAt(jp string, fn interface{}) *ConfigMapDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ConfigMapDie) DieWith(fn func(d *ConfigMapDie)) *ConfigMapDie {
+	nd := ConfigMapBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ConfigMapDie) DeepCopy() *ConfigMapDie {
 	r := *d.r.DeepCopy()
@@ -2084,6 +2154,13 @@ func (d *ContainerDie) DieStampAt(jp string, fn interface{}) *ContainerDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ContainerDie) DieWith(fn func(d *ContainerDie)) *ContainerDie {
+	nd := ContainerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2401,6 +2478,13 @@ func (d *ContainerPortDie) DieStampAt(jp string, fn interface{}) *ContainerPortD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ContainerPortDie) DieWith(fn func(d *ContainerPortDie)) *ContainerPortDie {
+	nd := ContainerPortBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ContainerPortDie) DeepCopy() *ContainerPortDie {
 	r := *d.r.DeepCopy()
@@ -2590,6 +2674,13 @@ func (d *EnvFromSourceDie) DieStampAt(jp string, fn interface{}) *EnvFromSourceD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EnvFromSourceDie) DieWith(fn func(d *EnvFromSourceDie)) *EnvFromSourceDie {
+	nd := EnvFromSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *EnvFromSourceDie) DeepCopy() *EnvFromSourceDie {
 	r := *d.r.DeepCopy()
@@ -2765,6 +2856,13 @@ func (d *ConfigMapEnvSourceDie) DieStampAt(jp string, fn interface{}) *ConfigMap
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ConfigMapEnvSourceDie) DieWith(fn func(d *ConfigMapEnvSourceDie)) *ConfigMapEnvSourceDie {
+	nd := ConfigMapEnvSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ConfigMapEnvSourceDie) DeepCopy() *ConfigMapEnvSourceDie {
 	r := *d.r.DeepCopy()
@@ -2933,6 +3031,13 @@ func (d *SecretEnvSourceDie) DieStampAt(jp string, fn interface{}) *SecretEnvSou
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SecretEnvSourceDie) DieWith(fn func(d *SecretEnvSourceDie)) *SecretEnvSourceDie {
+	nd := SecretEnvSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SecretEnvSourceDie) DeepCopy() *SecretEnvSourceDie {
 	r := *d.r.DeepCopy()
@@ -3099,6 +3204,13 @@ func (d *EnvVarDie) DieStampAt(jp string, fn interface{}) *EnvVarDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EnvVarDie) DieWith(fn func(d *EnvVarDie)) *EnvVarDie {
+	nd := EnvVarBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -3274,6 +3386,13 @@ func (d *EnvVarSourceDie) DieStampAt(jp string, fn interface{}) *EnvVarSourceDie
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EnvVarSourceDie) DieWith(fn func(d *EnvVarSourceDie)) *EnvVarSourceDie {
+	nd := EnvVarSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -3458,6 +3577,13 @@ func (d *ObjectFieldSelectorDie) DieStampAt(jp string, fn interface{}) *ObjectFi
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ObjectFieldSelectorDie) DieWith(fn func(d *ObjectFieldSelectorDie)) *ObjectFieldSelectorDie {
+	nd := ObjectFieldSelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ObjectFieldSelectorDie) DeepCopy() *ObjectFieldSelectorDie {
 	r := *d.r.DeepCopy()
@@ -3624,6 +3750,13 @@ func (d *ResourceFieldSelectorDie) DieStampAt(jp string, fn interface{}) *Resour
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ResourceFieldSelectorDie) DieWith(fn func(d *ResourceFieldSelectorDie)) *ResourceFieldSelectorDie {
+	nd := ResourceFieldSelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -3801,6 +3934,13 @@ func (d *ConfigMapKeySelectorDie) DieStampAt(jp string, fn interface{}) *ConfigM
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ConfigMapKeySelectorDie) DieWith(fn func(d *ConfigMapKeySelectorDie)) *ConfigMapKeySelectorDie {
+	nd := ConfigMapKeySelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ConfigMapKeySelectorDie) DeepCopy() *ConfigMapKeySelectorDie {
 	r := *d.r.DeepCopy()
@@ -3976,6 +4116,13 @@ func (d *SecretKeySelectorDie) DieStampAt(jp string, fn interface{}) *SecretKeyS
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SecretKeySelectorDie) DieWith(fn func(d *SecretKeySelectorDie)) *SecretKeySelectorDie {
+	nd := SecretKeySelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SecretKeySelectorDie) DeepCopy() *SecretKeySelectorDie {
 	r := *d.r.DeepCopy()
@@ -4149,6 +4296,13 @@ func (d *ResourceRequirementsDie) DieStampAt(jp string, fn interface{}) *Resourc
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ResourceRequirementsDie) DieWith(fn func(d *ResourceRequirementsDie)) *ResourceRequirementsDie {
+	nd := ResourceRequirementsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -4330,6 +4484,13 @@ func (d *ResourceClaimDie) DieStampAt(jp string, fn interface{}) *ResourceClaimD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ResourceClaimDie) DieWith(fn func(d *ResourceClaimDie)) *ResourceClaimDie {
+	nd := ResourceClaimBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ResourceClaimDie) DeepCopy() *ResourceClaimDie {
 	r := *d.r.DeepCopy()
@@ -4489,6 +4650,13 @@ func (d *ContainerResizePolicyDie) DieStampAt(jp string, fn interface{}) *Contai
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ContainerResizePolicyDie) DieWith(fn func(d *ContainerResizePolicyDie)) *ContainerResizePolicyDie {
+	nd := ContainerResizePolicyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -4657,6 +4825,13 @@ func (d *VolumeMountDie) DieStampAt(jp string, fn interface{}) *VolumeMountDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeMountDie) DieWith(fn func(d *VolumeMountDie)) *VolumeMountDie {
+	nd := VolumeMountBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -4855,6 +5030,13 @@ func (d *VolumeDeviceDie) DieStampAt(jp string, fn interface{}) *VolumeDeviceDie
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeDeviceDie) DieWith(fn func(d *VolumeDeviceDie)) *VolumeDeviceDie {
+	nd := VolumeDeviceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *VolumeDeviceDie) DeepCopy() *VolumeDeviceDie {
 	r := *d.r.DeepCopy()
@@ -5021,6 +5203,13 @@ func (d *ProbeDie) DieStampAt(jp string, fn interface{}) *ProbeDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ProbeDie) DieWith(fn func(d *ProbeDie)) *ProbeDie {
+	nd := ProbeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -5226,6 +5415,13 @@ func (d *LifecycleDie) DieStampAt(jp string, fn interface{}) *LifecycleDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LifecycleDie) DieWith(fn func(d *LifecycleDie)) *LifecycleDie {
+	nd := LifecycleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *LifecycleDie) DeepCopy() *LifecycleDie {
 	r := *d.r.DeepCopy()
@@ -5392,6 +5588,13 @@ func (d *LifecycleHandlerDie) DieStampAt(jp string, fn interface{}) *LifecycleHa
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LifecycleHandlerDie) DieWith(fn func(d *LifecycleHandlerDie)) *LifecycleHandlerDie {
+	nd := LifecycleHandlerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -5567,6 +5770,13 @@ func (d *ProbeHandlerDie) DieStampAt(jp string, fn interface{}) *ProbeHandlerDie
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ProbeHandlerDie) DieWith(fn func(d *ProbeHandlerDie)) *ProbeHandlerDie {
+	nd := ProbeHandlerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -5751,6 +5961,13 @@ func (d *ExecActionDie) DieStampAt(jp string, fn interface{}) *ExecActionDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ExecActionDie) DieWith(fn func(d *ExecActionDie)) *ExecActionDie {
+	nd := ExecActionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ExecActionDie) DeepCopy() *ExecActionDie {
 	r := *d.r.DeepCopy()
@@ -5910,6 +6127,13 @@ func (d *HTTPGetActionDie) DieStampAt(jp string, fn interface{}) *HTTPGetActionD
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *HTTPGetActionDie) DieWith(fn func(d *HTTPGetActionDie)) *HTTPGetActionDie {
+	nd := HTTPGetActionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -6115,6 +6339,13 @@ func (d *HTTPHeaderDie) DieStampAt(jp string, fn interface{}) *HTTPHeaderDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *HTTPHeaderDie) DieWith(fn func(d *HTTPHeaderDie)) *HTTPHeaderDie {
+	nd := HTTPHeaderBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *HTTPHeaderDie) DeepCopy() *HTTPHeaderDie {
 	r := *d.r.DeepCopy()
@@ -6281,6 +6512,13 @@ func (d *TCPSocketActionDie) DieStampAt(jp string, fn interface{}) *TCPSocketAct
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TCPSocketActionDie) DieWith(fn func(d *TCPSocketActionDie)) *TCPSocketActionDie {
+	nd := TCPSocketActionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -6465,6 +6703,13 @@ func (d *GRPCActionDie) DieStampAt(jp string, fn interface{}) *GRPCActionDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GRPCActionDie) DieWith(fn func(d *GRPCActionDie)) *GRPCActionDie {
+	nd := GRPCActionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *GRPCActionDie) DeepCopy() *GRPCActionDie {
 	r := *d.r.DeepCopy()
@@ -6633,6 +6878,13 @@ func (d *SecurityContextDie) DieStampAt(jp string, fn interface{}) *SecurityCont
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SecurityContextDie) DieWith(fn func(d *SecurityContextDie)) *SecurityContextDie {
+	nd := SecurityContextBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -6866,6 +7118,13 @@ func (d *CapabilitiesDie) DieStampAt(jp string, fn interface{}) *CapabilitiesDie
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CapabilitiesDie) DieWith(fn func(d *CapabilitiesDie)) *CapabilitiesDie {
+	nd := CapabilitiesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CapabilitiesDie) DeepCopy() *CapabilitiesDie {
 	r := *d.r.DeepCopy()
@@ -7032,6 +7291,13 @@ func (d *SELinuxOptionsDie) DieStampAt(jp string, fn interface{}) *SELinuxOption
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SELinuxOptionsDie) DieWith(fn func(d *SELinuxOptionsDie)) *SELinuxOptionsDie {
+	nd := SELinuxOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -7216,6 +7482,13 @@ func (d *WindowsSecurityContextOptionsDie) DieStampAt(jp string, fn interface{})
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *WindowsSecurityContextOptionsDie) DieWith(fn func(d *WindowsSecurityContextOptionsDie)) *WindowsSecurityContextOptionsDie {
+	nd := WindowsSecurityContextOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *WindowsSecurityContextOptionsDie) DeepCopy() *WindowsSecurityContextOptionsDie {
 	r := *d.r.DeepCopy()
@@ -7398,6 +7671,13 @@ func (d *SeccompProfileDie) DieStampAt(jp string, fn interface{}) *SeccompProfil
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SeccompProfileDie) DieWith(fn func(d *SeccompProfileDie)) *SeccompProfileDie {
+	nd := SeccompProfileBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SeccompProfileDie) DeepCopy() *SeccompProfileDie {
 	r := *d.r.DeepCopy()
@@ -7566,6 +7846,13 @@ func (d *ContainerStatusDie) DieStampAt(jp string, fn interface{}) *ContainerSta
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ContainerStatusDie) DieWith(fn func(d *ContainerStatusDie)) *ContainerStatusDie {
+	nd := ContainerStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -7801,6 +8088,13 @@ func (d *ContainerStateDie) DieStampAt(jp string, fn interface{}) *ContainerStat
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ContainerStateDie) DieWith(fn func(d *ContainerStateDie)) *ContainerStateDie {
+	nd := ContainerStateBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ContainerStateDie) DeepCopy() *ContainerStateDie {
 	r := *d.r.DeepCopy()
@@ -7976,6 +8270,13 @@ func (d *ContainerStateWaitingDie) DieStampAt(jp string, fn interface{}) *Contai
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ContainerStateWaitingDie) DieWith(fn func(d *ContainerStateWaitingDie)) *ContainerStateWaitingDie {
+	nd := ContainerStateWaitingBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ContainerStateWaitingDie) DeepCopy() *ContainerStateWaitingDie {
 	r := *d.r.DeepCopy()
@@ -8144,6 +8445,13 @@ func (d *ContainerStateRunningDie) DieStampAt(jp string, fn interface{}) *Contai
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ContainerStateRunningDie) DieWith(fn func(d *ContainerStateRunningDie)) *ContainerStateRunningDie {
+	nd := ContainerStateRunningBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ContainerStateRunningDie) DeepCopy() *ContainerStateRunningDie {
 	r := *d.r.DeepCopy()
@@ -8303,6 +8611,13 @@ func (d *ContainerStateTerminatedDie) DieStampAt(jp string, fn interface{}) *Con
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ContainerStateTerminatedDie) DieWith(fn func(d *ContainerStateTerminatedDie)) *ContainerStateTerminatedDie {
+	nd := ContainerStateTerminatedBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -8523,6 +8838,13 @@ func (d *EndpointsDie) DieStampAt(jp string, fn interface{}) *EndpointsDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EndpointsDie) DieWith(fn func(d *EndpointsDie)) *EndpointsDie {
+	nd := EndpointsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *EndpointsDie) DeepCopy() *EndpointsDie {
 	r := *d.r.DeepCopy()
@@ -8736,6 +9058,13 @@ func (d *EndpointSubsetDie) DieStampAt(jp string, fn interface{}) *EndpointSubse
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EndpointSubsetDie) DieWith(fn func(d *EndpointSubsetDie)) *EndpointSubsetDie {
+	nd := EndpointSubsetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *EndpointSubsetDie) DeepCopy() *EndpointSubsetDie {
 	r := *d.r.DeepCopy()
@@ -8909,6 +9238,13 @@ func (d *EndpointAddressDie) DieStampAt(jp string, fn interface{}) *EndpointAddr
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EndpointAddressDie) DieWith(fn func(d *EndpointAddressDie)) *EndpointAddressDie {
+	nd := EndpointAddressBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -9091,6 +9427,13 @@ func (d *EndpointPortDie) DieStampAt(jp string, fn interface{}) *EndpointPortDie
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EndpointPortDie) DieWith(fn func(d *EndpointPortDie)) *EndpointPortDie {
+	nd := EndpointPortBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -9294,6 +9637,13 @@ func (d *EventDie) DieStampAt(jp string, fn interface{}) *EventDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EventDie) DieWith(fn func(d *EventDie)) *EventDie {
+	nd := EventBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -9600,6 +9950,13 @@ func (d *EventSourceDie) DieStampAt(jp string, fn interface{}) *EventSourceDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EventSourceDie) DieWith(fn func(d *EventSourceDie)) *EventSourceDie {
+	nd := EventSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *EventSourceDie) DeepCopy() *EventSourceDie {
 	r := *d.r.DeepCopy()
@@ -9766,6 +10123,13 @@ func (d *EventSeriesDie) DieStampAt(jp string, fn interface{}) *EventSeriesDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EventSeriesDie) DieWith(fn func(d *EventSeriesDie)) *EventSeriesDie {
+	nd := EventSeriesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -9949,6 +10313,13 @@ func (d *LimitRangeDie) DieStampAt(jp string, fn interface{}) *LimitRangeDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LimitRangeDie) DieWith(fn func(d *LimitRangeDie)) *LimitRangeDie {
+	nd := LimitRangeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -10173,6 +10544,13 @@ func (d *LimitRangeSpecDie) DieStampAt(jp string, fn interface{}) *LimitRangeSpe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LimitRangeSpecDie) DieWith(fn func(d *LimitRangeSpecDie)) *LimitRangeSpecDie {
+	nd := LimitRangeSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *LimitRangeSpecDie) DeepCopy() *LimitRangeSpecDie {
 	r := *d.r.DeepCopy()
@@ -10332,6 +10710,13 @@ func (d *LimitRangeItemDie) DieStampAt(jp string, fn interface{}) *LimitRangeIte
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LimitRangeItemDie) DieWith(fn func(d *LimitRangeItemDie)) *LimitRangeItemDie {
+	nd := LimitRangeItemBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -10543,6 +10928,13 @@ func (d *NamespaceDie) DieStampAt(jp string, fn interface{}) *NamespaceDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NamespaceDie) DieWith(fn func(d *NamespaceDie)) *NamespaceDie {
+	nd := NamespaceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -10783,6 +11175,13 @@ func (d *NamespaceSpecDie) DieStampAt(jp string, fn interface{}) *NamespaceSpecD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NamespaceSpecDie) DieWith(fn func(d *NamespaceSpecDie)) *NamespaceSpecDie {
+	nd := NamespaceSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NamespaceSpecDie) DeepCopy() *NamespaceSpecDie {
 	r := *d.r.DeepCopy()
@@ -10942,6 +11341,13 @@ func (d *NamespaceStatusDie) DieStampAt(jp string, fn interface{}) *NamespaceSta
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NamespaceStatusDie) DieWith(fn func(d *NamespaceStatusDie)) *NamespaceStatusDie {
+	nd := NamespaceStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -11125,6 +11531,13 @@ func (d *NodeDie) DieStampAt(jp string, fn interface{}) *NodeDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeDie) DieWith(fn func(d *NodeDie)) *NodeDie {
+	nd := NodeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -11365,6 +11778,13 @@ func (d *NodeSpecDie) DieStampAt(jp string, fn interface{}) *NodeSpecDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeSpecDie) DieWith(fn func(d *NodeSpecDie)) *NodeSpecDie {
+	nd := NodeSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NodeSpecDie) DeepCopy() *NodeSpecDie {
 	r := *d.r.DeepCopy()
@@ -11568,6 +11988,13 @@ func (d *TaintDie) DieStampAt(jp string, fn interface{}) *TaintDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TaintDie) DieWith(fn func(d *TaintDie)) *TaintDie {
+	nd := TaintBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *TaintDie) DeepCopy() *TaintDie {
 	r := *d.r.DeepCopy()
@@ -11750,6 +12177,13 @@ func (d *NodeConfigSourceDie) DieStampAt(jp string, fn interface{}) *NodeConfigS
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeConfigSourceDie) DieWith(fn func(d *NodeConfigSourceDie)) *NodeConfigSourceDie {
+	nd := NodeConfigSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NodeConfigSourceDie) DeepCopy() *NodeConfigSourceDie {
 	r := *d.r.DeepCopy()
@@ -11909,6 +12343,13 @@ func (d *ConfigMapNodeConfigSourceDie) DieStampAt(jp string, fn interface{}) *Co
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ConfigMapNodeConfigSourceDie) DieWith(fn func(d *ConfigMapNodeConfigSourceDie)) *ConfigMapNodeConfigSourceDie {
+	nd := ConfigMapNodeConfigSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -12098,6 +12539,13 @@ func (d *NodeStatusDie) DieStampAt(jp string, fn interface{}) *NodeStatusDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeStatusDie) DieWith(fn func(d *NodeStatusDie)) *NodeStatusDie {
+	nd := NodeStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -12331,6 +12779,13 @@ func (d *NodeAddressDie) DieStampAt(jp string, fn interface{}) *NodeAddressDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeAddressDie) DieWith(fn func(d *NodeAddressDie)) *NodeAddressDie {
+	nd := NodeAddressBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NodeAddressDie) DeepCopy() *NodeAddressDie {
 	r := *d.r.DeepCopy()
@@ -12499,6 +12954,13 @@ func (d *NodeDaemonEndpointsDie) DieStampAt(jp string, fn interface{}) *NodeDaem
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeDaemonEndpointsDie) DieWith(fn func(d *NodeDaemonEndpointsDie)) *NodeDaemonEndpointsDie {
+	nd := NodeDaemonEndpointsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NodeDaemonEndpointsDie) DeepCopy() *NodeDaemonEndpointsDie {
 	r := *d.r.DeepCopy()
@@ -12660,6 +13122,13 @@ func (d *DaemonEndpointDie) DieStampAt(jp string, fn interface{}) *DaemonEndpoin
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DaemonEndpointDie) DieWith(fn func(d *DaemonEndpointDie)) *DaemonEndpointDie {
+	nd := DaemonEndpointBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *DaemonEndpointDie) DeepCopy() *DaemonEndpointDie {
 	r := *d.r.DeepCopy()
@@ -12819,6 +13288,13 @@ func (d *NodeSystemInfoDie) DieStampAt(jp string, fn interface{}) *NodeSystemInf
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeSystemInfoDie) DieWith(fn func(d *NodeSystemInfoDie)) *NodeSystemInfoDie {
+	nd := NodeSystemInfoBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -13045,6 +13521,13 @@ func (d *ContainerImageDie) DieStampAt(jp string, fn interface{}) *ContainerImag
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ContainerImageDie) DieWith(fn func(d *ContainerImageDie)) *ContainerImageDie {
+	nd := ContainerImageBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ContainerImageDie) DeepCopy() *ContainerImageDie {
 	r := *d.r.DeepCopy()
@@ -13213,6 +13696,13 @@ func (d *AttachedVolumeDie) DieStampAt(jp string, fn interface{}) *AttachedVolum
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AttachedVolumeDie) DieWith(fn func(d *AttachedVolumeDie)) *AttachedVolumeDie {
+	nd := AttachedVolumeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *AttachedVolumeDie) DeepCopy() *AttachedVolumeDie {
 	r := *d.r.DeepCopy()
@@ -13379,6 +13869,13 @@ func (d *NodeConfigStatusDie) DieStampAt(jp string, fn interface{}) *NodeConfigS
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeConfigStatusDie) DieWith(fn func(d *NodeConfigStatusDie)) *NodeConfigStatusDie {
+	nd := NodeConfigStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -13576,6 +14073,13 @@ func (d *PersistentVolumeDie) DieStampAt(jp string, fn interface{}) *PersistentV
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PersistentVolumeDie) DieWith(fn func(d *PersistentVolumeDie)) *PersistentVolumeDie {
+	nd := PersistentVolumeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -13816,6 +14320,13 @@ func (d *PersistentVolumeSpecDie) DieStampAt(jp string, fn interface{}) *Persist
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PersistentVolumeSpecDie) DieWith(fn func(d *PersistentVolumeSpecDie)) *PersistentVolumeSpecDie {
+	nd := PersistentVolumeSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PersistentVolumeSpecDie) DeepCopy() *PersistentVolumeSpecDie {
 	r := *d.r.DeepCopy()
@@ -14033,6 +14544,13 @@ func (d *PersistentVolumeStatusDie) DieStampAt(jp string, fn interface{}) *Persi
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PersistentVolumeStatusDie) DieWith(fn func(d *PersistentVolumeStatusDie)) *PersistentVolumeStatusDie {
+	nd := PersistentVolumeStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PersistentVolumeStatusDie) DeepCopy() *PersistentVolumeStatusDie {
 	r := *d.r.DeepCopy()
@@ -14206,6 +14724,13 @@ func (d *GlusterfsPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GlusterfsPersistentVolumeSourceDie) DieWith(fn func(d *GlusterfsPersistentVolumeSourceDie)) *GlusterfsPersistentVolumeSourceDie {
+	nd := GlusterfsPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -14388,6 +14913,13 @@ func (d *RBDPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) *RB
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RBDPersistentVolumeSourceDie) DieWith(fn func(d *RBDPersistentVolumeSourceDie)) *RBDPersistentVolumeSourceDie {
+	nd := RBDPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -14598,6 +15130,13 @@ func (d *ISCSIPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) *
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ISCSIPersistentVolumeSourceDie) DieWith(fn func(d *ISCSIPersistentVolumeSourceDie)) *ISCSIPersistentVolumeSourceDie {
+	nd := ISCSIPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -14831,6 +15370,13 @@ func (d *CinderPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) 
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CinderPersistentVolumeSourceDie) DieWith(fn func(d *CinderPersistentVolumeSourceDie)) *CinderPersistentVolumeSourceDie {
+	nd := CinderPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CinderPersistentVolumeSourceDie) DeepCopy() *CinderPersistentVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -15011,6 +15557,13 @@ func (d *CephFSPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) 
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CephFSPersistentVolumeSourceDie) DieWith(fn func(d *CephFSPersistentVolumeSourceDie)) *CephFSPersistentVolumeSourceDie {
+	nd := CephFSPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -15209,6 +15762,13 @@ func (d *FlexPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) *F
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *FlexPersistentVolumeSourceDie) DieWith(fn func(d *FlexPersistentVolumeSourceDie)) *FlexPersistentVolumeSourceDie {
+	nd := FlexPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *FlexPersistentVolumeSourceDie) DeepCopy() *FlexPersistentVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -15398,6 +15958,13 @@ func (d *AzureFilePersistentVolumeSourceDie) DieStampAt(jp string, fn interface{
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AzureFilePersistentVolumeSourceDie) DieWith(fn func(d *AzureFilePersistentVolumeSourceDie)) *AzureFilePersistentVolumeSourceDie {
+	nd := AzureFilePersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *AzureFilePersistentVolumeSourceDie) DeepCopy() *AzureFilePersistentVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -15578,6 +16145,13 @@ func (d *ScaleIOPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{})
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ScaleIOPersistentVolumeSourceDie) DieWith(fn func(d *ScaleIOPersistentVolumeSourceDie)) *ScaleIOPersistentVolumeSourceDie {
+	nd := ScaleIOPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -15804,6 +16378,13 @@ func (d *LocalVolumeSourceDie) DieStampAt(jp string, fn interface{}) *LocalVolum
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LocalVolumeSourceDie) DieWith(fn func(d *LocalVolumeSourceDie)) *LocalVolumeSourceDie {
+	nd := LocalVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *LocalVolumeSourceDie) DeepCopy() *LocalVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -15970,6 +16551,13 @@ func (d *StorageOSPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StorageOSPersistentVolumeSourceDie) DieWith(fn func(d *StorageOSPersistentVolumeSourceDie)) *StorageOSPersistentVolumeSourceDie {
+	nd := StorageOSPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -16159,6 +16747,13 @@ func (d *CSIPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) *CS
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CSIPersistentVolumeSourceDie) DieWith(fn func(d *CSIPersistentVolumeSourceDie)) *CSIPersistentVolumeSourceDie {
+	nd := CSIPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -16385,6 +16980,13 @@ func (d *VolumeNodeAffinityDie) DieStampAt(jp string, fn interface{}) *VolumeNod
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeNodeAffinityDie) DieWith(fn func(d *VolumeNodeAffinityDie)) *VolumeNodeAffinityDie {
+	nd := VolumeNodeAffinityBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *VolumeNodeAffinityDie) DeepCopy() *VolumeNodeAffinityDie {
 	r := *d.r.DeepCopy()
@@ -16546,6 +17148,13 @@ func (d *NodeSelectorDie) DieStampAt(jp string, fn interface{}) *NodeSelectorDie
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeSelectorDie) DieWith(fn func(d *NodeSelectorDie)) *NodeSelectorDie {
+	nd := NodeSelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NodeSelectorDie) DeepCopy() *NodeSelectorDie {
 	r := *d.r.DeepCopy()
@@ -16705,6 +17314,13 @@ func (d *NodeSelectorTermDie) DieStampAt(jp string, fn interface{}) *NodeSelecto
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeSelectorTermDie) DieWith(fn func(d *NodeSelectorTermDie)) *NodeSelectorTermDie {
+	nd := NodeSelectorTermBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -16873,6 +17489,13 @@ func (d *NodeSelectorRequirementDie) DieStampAt(jp string, fn interface{}) *Node
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NodeSelectorRequirementDie) DieWith(fn func(d *NodeSelectorRequirementDie)) *NodeSelectorRequirementDie {
+	nd := NodeSelectorRequirementBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -17063,6 +17686,13 @@ func (d *PersistentVolumeClaimDie) DieStampAt(jp string, fn interface{}) *Persis
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PersistentVolumeClaimDie) DieWith(fn func(d *PersistentVolumeClaimDie)) *PersistentVolumeClaimDie {
+	nd := PersistentVolumeClaimBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -17303,6 +17933,13 @@ func (d *PersistentVolumeClaimSpecDie) DieStampAt(jp string, fn interface{}) *Pe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PersistentVolumeClaimSpecDie) DieWith(fn func(d *PersistentVolumeClaimSpecDie)) *PersistentVolumeClaimSpecDie {
+	nd := PersistentVolumeClaimSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PersistentVolumeClaimSpecDie) DeepCopy() *PersistentVolumeClaimSpecDie {
 	r := *d.r.DeepCopy()
@@ -17513,6 +18150,13 @@ func (d *PersistentVolumeClaimStatusDie) DieStampAt(jp string, fn interface{}) *
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PersistentVolumeClaimStatusDie) DieWith(fn func(d *PersistentVolumeClaimStatusDie)) *PersistentVolumeClaimStatusDie {
+	nd := PersistentVolumeClaimStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PersistentVolumeClaimStatusDie) DeepCopy() *PersistentVolumeClaimStatusDie {
 	r := *d.r.DeepCopy()
@@ -17709,6 +18353,13 @@ func (d *PersistentVolumeClaimTemplateDie) DieStampAt(jp string, fn interface{})
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PersistentVolumeClaimTemplateDie) DieWith(fn func(d *PersistentVolumeClaimTemplateDie)) *PersistentVolumeClaimTemplateDie {
+	nd := PersistentVolumeClaimTemplateBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PersistentVolumeClaimTemplateDie) DeepCopy() *PersistentVolumeClaimTemplateDie {
 	r := *d.r.DeepCopy()
@@ -17890,6 +18541,13 @@ func (d *PodDie) DieStampAt(jp string, fn interface{}) *PodDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodDie) DieWith(fn func(d *PodDie)) *PodDie {
+	nd := PodBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -18128,6 +18786,13 @@ func (d *PodSpecDie) DieStampAt(jp string, fn interface{}) *PodSpecDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodSpecDie) DieWith(fn func(d *PodSpecDie)) *PodSpecDie {
+	nd := PodSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -18569,6 +19234,13 @@ func (d *PodSchedulingGateDie) DieStampAt(jp string, fn interface{}) *PodSchedul
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodSchedulingGateDie) DieWith(fn func(d *PodSchedulingGateDie)) *PodSchedulingGateDie {
+	nd := PodSchedulingGateBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodSchedulingGateDie) DeepCopy() *PodSchedulingGateDie {
 	r := *d.r.DeepCopy()
@@ -18728,6 +19400,13 @@ func (d *PodResourceClaimDie) DieStampAt(jp string, fn interface{}) *PodResource
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodResourceClaimDie) DieWith(fn func(d *PodResourceClaimDie)) *PodResourceClaimDie {
+	nd := PodResourceClaimBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -18896,6 +19575,13 @@ func (d *ClaimSourceDie) DieStampAt(jp string, fn interface{}) *ClaimSourceDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ClaimSourceDie) DieWith(fn func(d *ClaimSourceDie)) *ClaimSourceDie {
+	nd := ClaimSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -19070,6 +19756,13 @@ func (d *PodSecurityContextDie) DieStampAt(jp string, fn interface{}) *PodSecuri
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodSecurityContextDie) DieWith(fn func(d *PodSecurityContextDie)) *PodSecurityContextDie {
+	nd := PodSecurityContextBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -19300,6 +19993,13 @@ func (d *SysctlDie) DieStampAt(jp string, fn interface{}) *SysctlDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SysctlDie) DieWith(fn func(d *SysctlDie)) *SysctlDie {
+	nd := SysctlBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SysctlDie) DeepCopy() *SysctlDie {
 	r := *d.r.DeepCopy()
@@ -19466,6 +20166,13 @@ func (d *TolerationDie) DieStampAt(jp string, fn interface{}) *TolerationDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TolerationDie) DieWith(fn func(d *TolerationDie)) *TolerationDie {
+	nd := TolerationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -19657,6 +20364,13 @@ func (d *HostAliasDie) DieStampAt(jp string, fn interface{}) *HostAliasDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *HostAliasDie) DieWith(fn func(d *HostAliasDie)) *HostAliasDie {
+	nd := HostAliasBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *HostAliasDie) DeepCopy() *HostAliasDie {
 	r := *d.r.DeepCopy()
@@ -19823,6 +20537,13 @@ func (d *PodDNSConfigDie) DieStampAt(jp string, fn interface{}) *PodDNSConfigDie
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodDNSConfigDie) DieWith(fn func(d *PodDNSConfigDie)) *PodDNSConfigDie {
+	nd := PodDNSConfigBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -20000,6 +20721,13 @@ func (d *PodDNSConfigOptionDie) DieStampAt(jp string, fn interface{}) *PodDNSCon
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodDNSConfigOptionDie) DieWith(fn func(d *PodDNSConfigOptionDie)) *PodDNSConfigOptionDie {
+	nd := PodDNSConfigOptionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodDNSConfigOptionDie) DeepCopy() *PodDNSConfigOptionDie {
 	r := *d.r.DeepCopy()
@@ -20167,6 +20895,13 @@ func (d *PodReadinessGateDie) DieStampAt(jp string, fn interface{}) *PodReadines
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodReadinessGateDie) DieWith(fn func(d *PodReadinessGateDie)) *PodReadinessGateDie {
+	nd := PodReadinessGateBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodReadinessGateDie) DeepCopy() *PodReadinessGateDie {
 	r := *d.r.DeepCopy()
@@ -20326,6 +21061,13 @@ func (d *TopologySpreadConstraintDie) DieStampAt(jp string, fn interface{}) *Top
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TopologySpreadConstraintDie) DieWith(fn func(d *TopologySpreadConstraintDie)) *TopologySpreadConstraintDie {
+	nd := TopologySpreadConstraintBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -20548,6 +21290,13 @@ func (d *PodOSDie) DieStampAt(jp string, fn interface{}) *PodOSDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodOSDie) DieWith(fn func(d *PodOSDie)) *PodOSDie {
+	nd := PodOSBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodOSDie) DeepCopy() *PodOSDie {
 	r := *d.r.DeepCopy()
@@ -20707,6 +21456,13 @@ func (d *PodStatusDie) DieStampAt(jp string, fn interface{}) *PodStatusDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodStatusDie) DieWith(fn func(d *PodStatusDie)) *PodStatusDie {
+	nd := PodStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -20980,6 +21736,13 @@ func (d *PodTemplateDie) DieStampAt(jp string, fn interface{}) *PodTemplateDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodTemplateDie) DieWith(fn func(d *PodTemplateDie)) *PodTemplateDie {
+	nd := PodTemplateBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodTemplateDie) DeepCopy() *PodTemplateDie {
 	r := *d.r.DeepCopy()
@@ -21193,6 +21956,13 @@ func (d *PodTemplateSpecDie) DieStampAt(jp string, fn interface{}) *PodTemplateS
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodTemplateSpecDie) DieWith(fn func(d *PodTemplateSpecDie)) *PodTemplateSpecDie {
+	nd := PodTemplateSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodTemplateSpecDie) DeepCopy() *PodTemplateSpecDie {
 	r := *d.r.DeepCopy()
@@ -21374,6 +22144,13 @@ func (d *ReplicationControllerDie) DieStampAt(jp string, fn interface{}) *Replic
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ReplicationControllerDie) DieWith(fn func(d *ReplicationControllerDie)) *ReplicationControllerDie {
+	nd := ReplicationControllerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -21614,6 +22391,13 @@ func (d *ReplicationControllerSpecDie) DieStampAt(jp string, fn interface{}) *Re
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ReplicationControllerSpecDie) DieWith(fn func(d *ReplicationControllerSpecDie)) *ReplicationControllerSpecDie {
+	nd := ReplicationControllerSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ReplicationControllerSpecDie) DeepCopy() *ReplicationControllerSpecDie {
 	r := *d.r.DeepCopy()
@@ -21794,6 +22578,13 @@ func (d *ReplicationControllerStatusDie) DieStampAt(jp string, fn interface{}) *
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ReplicationControllerStatusDie) DieWith(fn func(d *ReplicationControllerStatusDie)) *ReplicationControllerStatusDie {
+	nd := ReplicationControllerStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -22005,6 +22796,13 @@ func (d *ResourceQuotaDie) DieStampAt(jp string, fn interface{}) *ResourceQuotaD
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ResourceQuotaDie) DieWith(fn func(d *ResourceQuotaDie)) *ResourceQuotaDie {
+	nd := ResourceQuotaBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -22245,6 +23043,13 @@ func (d *ResourceQuotaSpecDie) DieStampAt(jp string, fn interface{}) *ResourceQu
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ResourceQuotaSpecDie) DieWith(fn func(d *ResourceQuotaSpecDie)) *ResourceQuotaSpecDie {
+	nd := ResourceQuotaSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ResourceQuotaSpecDie) DeepCopy() *ResourceQuotaSpecDie {
 	r := *d.r.DeepCopy()
@@ -22420,6 +23225,13 @@ func (d *ScopeSelectorDie) DieStampAt(jp string, fn interface{}) *ScopeSelectorD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ScopeSelectorDie) DieWith(fn func(d *ScopeSelectorDie)) *ScopeSelectorDie {
+	nd := ScopeSelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ScopeSelectorDie) DeepCopy() *ScopeSelectorDie {
 	r := *d.r.DeepCopy()
@@ -22579,6 +23391,13 @@ func (d *ScopedResourceSelectorRequirementDie) DieStampAt(jp string, fn interfac
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ScopedResourceSelectorRequirementDie) DieWith(fn func(d *ScopedResourceSelectorRequirementDie)) *ScopedResourceSelectorRequirementDie {
+	nd := ScopedResourceSelectorRequirementBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -22754,6 +23573,13 @@ func (d *ResourceQuotaStatusDie) DieStampAt(jp string, fn interface{}) *Resource
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ResourceQuotaStatusDie) DieWith(fn func(d *ResourceQuotaStatusDie)) *ResourceQuotaStatusDie {
+	nd := ResourceQuotaStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -22937,6 +23763,13 @@ func (d *SecretDie) DieStampAt(jp string, fn interface{}) *SecretDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SecretDie) DieWith(fn func(d *SecretDie)) *SecretDie {
+	nd := SecretBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -23172,6 +24005,13 @@ func (d *ServiceDie) DieStampAt(jp string, fn interface{}) *ServiceDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServiceDie) DieWith(fn func(d *ServiceDie)) *ServiceDie {
+	nd := ServiceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -23410,6 +24250,13 @@ func (d *ServiceSpecDie) DieStampAt(jp string, fn interface{}) *ServiceSpecDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServiceSpecDie) DieWith(fn func(d *ServiceSpecDie)) *ServiceSpecDie {
+	nd := ServiceSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -23703,6 +24550,13 @@ func (d *ServicePortDie) DieStampAt(jp string, fn interface{}) *ServicePortDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServicePortDie) DieWith(fn func(d *ServicePortDie)) *ServicePortDie {
+	nd := ServicePortBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ServicePortDie) DeepCopy() *ServicePortDie {
 	r := *d.r.DeepCopy()
@@ -23913,6 +24767,13 @@ func (d *SessionAffinityConfigDie) DieStampAt(jp string, fn interface{}) *Sessio
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SessionAffinityConfigDie) DieWith(fn func(d *SessionAffinityConfigDie)) *SessionAffinityConfigDie {
+	nd := SessionAffinityConfigBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SessionAffinityConfigDie) DeepCopy() *SessionAffinityConfigDie {
 	r := *d.r.DeepCopy()
@@ -24074,6 +24935,13 @@ func (d *ClientIPConfigDie) DieStampAt(jp string, fn interface{}) *ClientIPConfi
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ClientIPConfigDie) DieWith(fn func(d *ClientIPConfigDie)) *ClientIPConfigDie {
+	nd := ClientIPConfigBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ClientIPConfigDie) DeepCopy() *ClientIPConfigDie {
 	r := *d.r.DeepCopy()
@@ -24233,6 +25101,13 @@ func (d *ServiceStatusDie) DieStampAt(jp string, fn interface{}) *ServiceStatusD
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServiceStatusDie) DieWith(fn func(d *ServiceStatusDie)) *ServiceStatusDie {
+	nd := ServiceStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -24403,6 +25278,13 @@ func (d *LoadBalancerStatusDie) DieStampAt(jp string, fn interface{}) *LoadBalan
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LoadBalancerStatusDie) DieWith(fn func(d *LoadBalancerStatusDie)) *LoadBalancerStatusDie {
+	nd := LoadBalancerStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *LoadBalancerStatusDie) DeepCopy() *LoadBalancerStatusDie {
 	r := *d.r.DeepCopy()
@@ -24562,6 +25444,13 @@ func (d *LoadBalancerIngressDie) DieStampAt(jp string, fn interface{}) *LoadBala
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LoadBalancerIngressDie) DieWith(fn func(d *LoadBalancerIngressDie)) *LoadBalancerIngressDie {
+	nd := LoadBalancerIngressBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -24737,6 +25626,13 @@ func (d *PortStatusDie) DieStampAt(jp string, fn interface{}) *PortStatusDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PortStatusDie) DieWith(fn func(d *PortStatusDie)) *PortStatusDie {
+	nd := PortStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -24927,6 +25823,13 @@ func (d *ServiceAccountDie) DieStampAt(jp string, fn interface{}) *ServiceAccoun
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServiceAccountDie) DieWith(fn func(d *ServiceAccountDie)) *ServiceAccountDie {
+	nd := ServiceAccountBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -25156,6 +26059,13 @@ func (d *VolumeDie) DieStampAt(jp string, fn interface{}) *VolumeDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeDie) DieWith(fn func(d *VolumeDie)) *VolumeDie {
+	nd := VolumeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *VolumeDie) DeepCopy() *VolumeDie {
 	r := *d.r.DeepCopy()
@@ -25322,6 +26232,13 @@ func (d *HostPathVolumeSourceDie) DieStampAt(jp string, fn interface{}) *HostPat
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *HostPathVolumeSourceDie) DieWith(fn func(d *HostPathVolumeSourceDie)) *HostPathVolumeSourceDie {
+	nd := HostPathVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -25492,6 +26409,13 @@ func (d *EmptyDirVolumeSourceDie) DieStampAt(jp string, fn interface{}) *EmptyDi
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EmptyDirVolumeSourceDie) DieWith(fn func(d *EmptyDirVolumeSourceDie)) *EmptyDirVolumeSourceDie {
+	nd := EmptyDirVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *EmptyDirVolumeSourceDie) DeepCopy() *EmptyDirVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -25658,6 +26582,13 @@ func (d *GCEPersistentDiskVolumeSourceDie) DieStampAt(jp string, fn interface{})
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GCEPersistentDiskVolumeSourceDie) DieWith(fn func(d *GCEPersistentDiskVolumeSourceDie)) *GCEPersistentDiskVolumeSourceDie {
+	nd := GCEPersistentDiskVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -25842,6 +26773,13 @@ func (d *AWSElasticBlockStoreVolumeSourceDie) DieStampAt(jp string, fn interface
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AWSElasticBlockStoreVolumeSourceDie) DieWith(fn func(d *AWSElasticBlockStoreVolumeSourceDie)) *AWSElasticBlockStoreVolumeSourceDie {
+	nd := AWSElasticBlockStoreVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *AWSElasticBlockStoreVolumeSourceDie) DeepCopy() *AWSElasticBlockStoreVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -26024,6 +26962,13 @@ func (d *GitRepoVolumeSourceDie) DieStampAt(jp string, fn interface{}) *GitRepoV
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GitRepoVolumeSourceDie) DieWith(fn func(d *GitRepoVolumeSourceDie)) *GitRepoVolumeSourceDie {
+	nd := GitRepoVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *GitRepoVolumeSourceDie) DeepCopy() *GitRepoVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -26197,6 +27142,13 @@ func (d *SecretVolumeSourceDie) DieStampAt(jp string, fn interface{}) *SecretVol
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SecretVolumeSourceDie) DieWith(fn func(d *SecretVolumeSourceDie)) *SecretVolumeSourceDie {
+	nd := SecretVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -26381,6 +27333,13 @@ func (d *NFSVolumeSourceDie) DieStampAt(jp string, fn interface{}) *NFSVolumeSou
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NFSVolumeSourceDie) DieWith(fn func(d *NFSVolumeSourceDie)) *NFSVolumeSourceDie {
+	nd := NFSVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NFSVolumeSourceDie) DeepCopy() *NFSVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -26554,6 +27513,13 @@ func (d *ISCSIVolumeSourceDie) DieStampAt(jp string, fn interface{}) *ISCSIVolum
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ISCSIVolumeSourceDie) DieWith(fn func(d *ISCSIVolumeSourceDie)) *ISCSIVolumeSourceDie {
+	nd := ISCSIVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -26787,6 +27753,13 @@ func (d *GlusterfsVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Gluste
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GlusterfsVolumeSourceDie) DieWith(fn func(d *GlusterfsVolumeSourceDie)) *GlusterfsVolumeSourceDie {
+	nd := GlusterfsVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *GlusterfsVolumeSourceDie) DeepCopy() *GlusterfsVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -26962,6 +27935,13 @@ func (d *PersistentVolumeClaimVolumeSourceDie) DieStampAt(jp string, fn interfac
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PersistentVolumeClaimVolumeSourceDie) DieWith(fn func(d *PersistentVolumeClaimVolumeSourceDie)) *PersistentVolumeClaimVolumeSourceDie {
+	nd := PersistentVolumeClaimVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PersistentVolumeClaimVolumeSourceDie) DeepCopy() *PersistentVolumeClaimVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -27128,6 +28108,13 @@ func (d *RBDVolumeSourceDie) DieStampAt(jp string, fn interface{}) *RBDVolumeSou
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RBDVolumeSourceDie) DieWith(fn func(d *RBDVolumeSourceDie)) *RBDVolumeSourceDie {
+	nd := RBDVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -27340,6 +28327,13 @@ func (d *FlexVolumeSourceDie) DieStampAt(jp string, fn interface{}) *FlexVolumeS
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *FlexVolumeSourceDie) DieWith(fn func(d *FlexVolumeSourceDie)) *FlexVolumeSourceDie {
+	nd := FlexVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *FlexVolumeSourceDie) DeepCopy() *FlexVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -27529,6 +28523,13 @@ func (d *CinderVolumeSourceDie) DieStampAt(jp string, fn interface{}) *CinderVol
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CinderVolumeSourceDie) DieWith(fn func(d *CinderVolumeSourceDie)) *CinderVolumeSourceDie {
+	nd := CinderVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CinderVolumeSourceDie) DeepCopy() *CinderVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -27709,6 +28710,13 @@ func (d *CephFSVolumeSourceDie) DieStampAt(jp string, fn interface{}) *CephFSVol
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CephFSVolumeSourceDie) DieWith(fn func(d *CephFSVolumeSourceDie)) *CephFSVolumeSourceDie {
+	nd := CephFSVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -27907,6 +28915,13 @@ func (d *FlockerVolumeSourceDie) DieStampAt(jp string, fn interface{}) *FlockerV
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *FlockerVolumeSourceDie) DieWith(fn func(d *FlockerVolumeSourceDie)) *FlockerVolumeSourceDie {
+	nd := FlockerVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *FlockerVolumeSourceDie) DeepCopy() *FlockerVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -28075,6 +29090,13 @@ func (d *DownwardAPIVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Down
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DownwardAPIVolumeSourceDie) DieWith(fn func(d *DownwardAPIVolumeSourceDie)) *DownwardAPIVolumeSourceDie {
+	nd := DownwardAPIVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *DownwardAPIVolumeSourceDie) DeepCopy() *DownwardAPIVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -28241,6 +29263,13 @@ func (d *DownwardAPIVolumeFileDie) DieStampAt(jp string, fn interface{}) *Downwa
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DownwardAPIVolumeFileDie) DieWith(fn func(d *DownwardAPIVolumeFileDie)) *DownwardAPIVolumeFileDie {
+	nd := DownwardAPIVolumeFileBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -28423,6 +29452,13 @@ func (d *FCVolumeSourceDie) DieStampAt(jp string, fn interface{}) *FCVolumeSourc
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *FCVolumeSourceDie) DieWith(fn func(d *FCVolumeSourceDie)) *FCVolumeSourceDie {
+	nd := FCVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -28614,6 +29650,13 @@ func (d *AzureFileVolumeSourceDie) DieStampAt(jp string, fn interface{}) *AzureF
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AzureFileVolumeSourceDie) DieWith(fn func(d *AzureFileVolumeSourceDie)) *AzureFileVolumeSourceDie {
+	nd := AzureFileVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *AzureFileVolumeSourceDie) DeepCopy() *AzureFileVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -28787,6 +29830,13 @@ func (d *ConfigMapVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Config
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ConfigMapVolumeSourceDie) DieWith(fn func(d *ConfigMapVolumeSourceDie)) *ConfigMapVolumeSourceDie {
+	nd := ConfigMapVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -28970,6 +30020,13 @@ func (d *VsphereVirtualDiskVolumeSourceDie) DieStampAt(jp string, fn interface{}
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VsphereVirtualDiskVolumeSourceDie) DieWith(fn func(d *VsphereVirtualDiskVolumeSourceDie)) *VsphereVirtualDiskVolumeSourceDie {
+	nd := VsphereVirtualDiskVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *VsphereVirtualDiskVolumeSourceDie) DeepCopy() *VsphereVirtualDiskVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -29150,6 +30207,13 @@ func (d *QuobyteVolumeSourceDie) DieStampAt(jp string, fn interface{}) *QuobyteV
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *QuobyteVolumeSourceDie) DieWith(fn func(d *QuobyteVolumeSourceDie)) *QuobyteVolumeSourceDie {
+	nd := QuobyteVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -29348,6 +30412,13 @@ func (d *AzureDiskVolumeSourceDie) DieStampAt(jp string, fn interface{}) *AzureD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AzureDiskVolumeSourceDie) DieWith(fn func(d *AzureDiskVolumeSourceDie)) *AzureDiskVolumeSourceDie {
+	nd := AzureDiskVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *AzureDiskVolumeSourceDie) DeepCopy() *AzureDiskVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -29544,6 +30615,13 @@ func (d *PhotonPersistentDiskVolumeSourceDie) DieStampAt(jp string, fn interface
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PhotonPersistentDiskVolumeSourceDie) DieWith(fn func(d *PhotonPersistentDiskVolumeSourceDie)) *PhotonPersistentDiskVolumeSourceDie {
+	nd := PhotonPersistentDiskVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PhotonPersistentDiskVolumeSourceDie) DeepCopy() *PhotonPersistentDiskVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -29712,6 +30790,13 @@ func (d *ProjectedVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Projec
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ProjectedVolumeSourceDie) DieWith(fn func(d *ProjectedVolumeSourceDie)) *ProjectedVolumeSourceDie {
+	nd := ProjectedVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ProjectedVolumeSourceDie) DeepCopy() *ProjectedVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -29878,6 +30963,13 @@ func (d *VolumeProjectionDie) DieStampAt(jp string, fn interface{}) *VolumeProje
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeProjectionDie) DieWith(fn func(d *VolumeProjectionDie)) *VolumeProjectionDie {
+	nd := VolumeProjectionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -30062,6 +31154,13 @@ func (d *SecretProjectionDie) DieStampAt(jp string, fn interface{}) *SecretProje
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SecretProjectionDie) DieWith(fn func(d *SecretProjectionDie)) *SecretProjectionDie {
+	nd := SecretProjectionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SecretProjectionDie) DeepCopy() *SecretProjectionDie {
 	r := *d.r.DeepCopy()
@@ -30236,6 +31335,13 @@ func (d *DownwardAPIProjectionDie) DieStampAt(jp string, fn interface{}) *Downwa
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DownwardAPIProjectionDie) DieWith(fn func(d *DownwardAPIProjectionDie)) *DownwardAPIProjectionDie {
+	nd := DownwardAPIProjectionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *DownwardAPIProjectionDie) DeepCopy() *DownwardAPIProjectionDie {
 	r := *d.r.DeepCopy()
@@ -30395,6 +31501,13 @@ func (d *ConfigMapProjectionDie) DieStampAt(jp string, fn interface{}) *ConfigMa
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ConfigMapProjectionDie) DieWith(fn func(d *ConfigMapProjectionDie)) *ConfigMapProjectionDie {
+	nd := ConfigMapProjectionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -30569,6 +31682,13 @@ func (d *ServiceAccountTokenProjectionDie) DieStampAt(jp string, fn interface{})
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServiceAccountTokenProjectionDie) DieWith(fn func(d *ServiceAccountTokenProjectionDie)) *ServiceAccountTokenProjectionDie {
+	nd := ServiceAccountTokenProjectionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -30746,6 +31866,13 @@ func (d *PortworxVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Portwor
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PortworxVolumeSourceDie) DieWith(fn func(d *PortworxVolumeSourceDie)) *PortworxVolumeSourceDie {
+	nd := PortworxVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PortworxVolumeSourceDie) DeepCopy() *PortworxVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -30919,6 +32046,13 @@ func (d *ScaleIOVolumeSourceDie) DieStampAt(jp string, fn interface{}) *ScaleIOV
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ScaleIOVolumeSourceDie) DieWith(fn func(d *ScaleIOVolumeSourceDie)) *ScaleIOVolumeSourceDie {
+	nd := ScaleIOVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -31145,6 +32279,13 @@ func (d *StorageOSVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Storag
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StorageOSVolumeSourceDie) DieWith(fn func(d *StorageOSVolumeSourceDie)) *StorageOSVolumeSourceDie {
+	nd := StorageOSVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *StorageOSVolumeSourceDie) DeepCopy() *StorageOSVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -31332,6 +32473,13 @@ func (d *CSIVolumeSourceDie) DieStampAt(jp string, fn interface{}) *CSIVolumeSou
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CSIVolumeSourceDie) DieWith(fn func(d *CSIVolumeSourceDie)) *CSIVolumeSourceDie {
+	nd := CSIVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -31523,6 +32671,13 @@ func (d *EphemeralVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Epheme
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EphemeralVolumeSourceDie) DieWith(fn func(d *EphemeralVolumeSourceDie)) *EphemeralVolumeSourceDie {
+	nd := EphemeralVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *EphemeralVolumeSourceDie) DeepCopy() *EphemeralVolumeSourceDie {
 	r := *d.r.DeepCopy()
@@ -31688,6 +32843,13 @@ func (d *KeyToPathDie) DieStampAt(jp string, fn interface{}) *KeyToPathDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *KeyToPathDie) DieWith(fn func(d *KeyToPathDie)) *KeyToPathDie {
+	nd := KeyToPathBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/events/v1/zz_generated.die.go
+++ b/apis/events/v1/zz_generated.die.go
@@ -197,6 +197,13 @@ func (d *EventDie) DieStampAt(jp string, fn interface{}) *EventDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EventDie) DieWith(fn func(d *EventDie)) *EventDie {
+	nd := EventBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *EventDie) DeepCopy() *EventDie {
 	r := *d.r.DeepCopy()
@@ -499,6 +506,13 @@ func (d *EventSeriesDie) DieStampAt(jp string, fn interface{}) *EventSeriesDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *EventSeriesDie) DieWith(fn func(d *EventSeriesDie)) *EventSeriesDie {
+	nd := EventSeriesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/meta/v1/zz_generated.die.go
+++ b/apis/meta/v1/zz_generated.die.go
@@ -178,6 +178,13 @@ func (d *ConditionDie) DieStampAt(jp string, fn interface{}) *ConditionDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ConditionDie) DieWith(fn func(d *ConditionDie)) *ConditionDie {
+	nd := ConditionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ConditionDie) DeepCopy() *ConditionDie {
 	r := *d.r.DeepCopy()
@@ -374,6 +381,13 @@ func (d *GroupResourceDie) DieStampAt(jp string, fn interface{}) *GroupResourceD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GroupResourceDie) DieWith(fn func(d *GroupResourceDie)) *GroupResourceDie {
+	nd := GroupResourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *GroupResourceDie) DeepCopy() *GroupResourceDie {
 	r := *d.r.DeepCopy()
@@ -540,6 +554,13 @@ func (d *GroupVersionDie) DieStampAt(jp string, fn interface{}) *GroupVersionDie
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GroupVersionDie) DieWith(fn func(d *GroupVersionDie)) *GroupVersionDie {
+	nd := GroupVersionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *GroupVersionDie) DeepCopy() *GroupVersionDie {
 	r := *d.r.DeepCopy()
@@ -704,6 +725,13 @@ func (d *GroupVersionKindDie) DieStampAt(jp string, fn interface{}) *GroupVersio
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GroupVersionKindDie) DieWith(fn func(d *GroupVersionKindDie)) *GroupVersionKindDie {
+	nd := GroupVersionKindBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -878,6 +906,13 @@ func (d *GroupVersionResourceDie) DieStampAt(jp string, fn interface{}) *GroupVe
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GroupVersionResourceDie) DieWith(fn func(d *GroupVersionResourceDie)) *GroupVersionResourceDie {
+	nd := GroupVersionResourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *GroupVersionResourceDie) DeepCopy() *GroupVersionResourceDie {
 	r := *d.r.DeepCopy()
@@ -1050,6 +1085,13 @@ func (d *GroupVersionForDiscoveryDie) DieStampAt(jp string, fn interface{}) *Gro
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *GroupVersionForDiscoveryDie) DieWith(fn func(d *GroupVersionForDiscoveryDie)) *GroupVersionForDiscoveryDie {
+	nd := GroupVersionForDiscoveryBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *GroupVersionForDiscoveryDie) DeepCopy() *GroupVersionForDiscoveryDie {
 	r := *d.r.DeepCopy()
@@ -1216,6 +1258,13 @@ func (d *ListMetaDie) DieStampAt(jp string, fn interface{}) *ListMetaDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ListMetaDie) DieWith(fn func(d *ListMetaDie)) *ListMetaDie {
+	nd := ListMetaBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1398,6 +1447,13 @@ func (d *ObjectMetaDie) DieStampAt(jp string, fn interface{}) *ObjectMetaDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ObjectMetaDie) DieWith(fn func(d *ObjectMetaDie)) *ObjectMetaDie {
+	nd := ObjectMetaBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1673,6 +1729,13 @@ func (d *ManagedFieldsEntryDie) DieStampAt(jp string, fn interface{}) *ManagedFi
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ManagedFieldsEntryDie) DieWith(fn func(d *ManagedFieldsEntryDie)) *ManagedFieldsEntryDie {
+	nd := ManagedFieldsEntryBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ManagedFieldsEntryDie) DeepCopy() *ManagedFieldsEntryDie {
 	r := *d.r.DeepCopy()
@@ -1876,6 +1939,13 @@ func (d *LabelSelectorDie) DieStampAt(jp string, fn interface{}) *LabelSelectorD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *LabelSelectorDie) DieWith(fn func(d *LabelSelectorDie)) *LabelSelectorDie {
+	nd := LabelSelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *LabelSelectorDie) DeepCopy() *LabelSelectorDie {
 	r := *d.r.DeepCopy()
@@ -2042,6 +2112,13 @@ func (d *StatusDie) DieStampAt(jp string, fn interface{}) *StatusDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StatusDie) DieWith(fn func(d *StatusDie)) *StatusDie {
+	nd := StatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2246,6 +2323,13 @@ func (d *StatusDetailsDie) DieStampAt(jp string, fn interface{}) *StatusDetailsD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StatusDetailsDie) DieWith(fn func(d *StatusDetailsDie)) *StatusDetailsDie {
+	nd := StatusDetailsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *StatusDetailsDie) DeepCopy() *StatusDetailsDie {
 	r := *d.r.DeepCopy()
@@ -2440,6 +2524,13 @@ func (d *StatusCauseDie) DieStampAt(jp string, fn interface{}) *StatusCauseDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StatusCauseDie) DieWith(fn func(d *StatusCauseDie)) *StatusCauseDie {
+	nd := StatusCauseBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/networking/v1/zz_generated.die.go
+++ b/apis/networking/v1/zz_generated.die.go
@@ -198,6 +198,13 @@ func (d *IngressDie) DieStampAt(jp string, fn interface{}) *IngressDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressDie) DieWith(fn func(d *IngressDie)) *IngressDie {
+	nd := IngressBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *IngressDie) DeepCopy() *IngressDie {
 	r := *d.r.DeepCopy()
@@ -436,6 +443,13 @@ func (d *IngressSpecDie) DieStampAt(jp string, fn interface{}) *IngressSpecDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressSpecDie) DieWith(fn func(d *IngressSpecDie)) *IngressSpecDie {
+	nd := IngressSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *IngressSpecDie) DeepCopy() *IngressSpecDie {
 	r := *d.r.DeepCopy()
@@ -618,6 +632,13 @@ func (d *IngressBackendDie) DieStampAt(jp string, fn interface{}) *IngressBacken
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressBackendDie) DieWith(fn func(d *IngressBackendDie)) *IngressBackendDie {
+	nd := IngressBackendBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *IngressBackendDie) DeepCopy() *IngressBackendDie {
 	r := *d.r.DeepCopy()
@@ -784,6 +805,13 @@ func (d *IngressServiceBackendDie) DieStampAt(jp string, fn interface{}) *Ingres
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressServiceBackendDie) DieWith(fn func(d *IngressServiceBackendDie)) *IngressServiceBackendDie {
+	nd := IngressServiceBackendBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -954,6 +982,13 @@ func (d *ServiceBackendPortDie) DieStampAt(jp string, fn interface{}) *ServiceBa
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *ServiceBackendPortDie) DieWith(fn func(d *ServiceBackendPortDie)) *ServiceBackendPortDie {
+	nd := ServiceBackendPortBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *ServiceBackendPortDie) DeepCopy() *ServiceBackendPortDie {
 	r := *d.r.DeepCopy()
@@ -1122,6 +1157,13 @@ func (d *IngressTLSDie) DieStampAt(jp string, fn interface{}) *IngressTLSDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressTLSDie) DieWith(fn func(d *IngressTLSDie)) *IngressTLSDie {
+	nd := IngressTLSBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *IngressTLSDie) DeepCopy() *IngressTLSDie {
 	r := *d.r.DeepCopy()
@@ -1288,6 +1330,13 @@ func (d *IngressRuleDie) DieStampAt(jp string, fn interface{}) *IngressRuleDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressRuleDie) DieWith(fn func(d *IngressRuleDie)) *IngressRuleDie {
+	nd := IngressRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1460,6 +1509,13 @@ func (d *HTTPIngressRuleValueDie) DieStampAt(jp string, fn interface{}) *HTTPIng
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *HTTPIngressRuleValueDie) DieWith(fn func(d *HTTPIngressRuleValueDie)) *HTTPIngressRuleValueDie {
+	nd := HTTPIngressRuleValueBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *HTTPIngressRuleValueDie) DeepCopy() *HTTPIngressRuleValueDie {
 	r := *d.r.DeepCopy()
@@ -1619,6 +1675,13 @@ func (d *HTTPIngressPathDie) DieStampAt(jp string, fn interface{}) *HTTPIngressP
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *HTTPIngressPathDie) DieWith(fn func(d *HTTPIngressPathDie)) *HTTPIngressPathDie {
+	nd := HTTPIngressPathBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1796,6 +1859,13 @@ func (d *IngressStatusDie) DieStampAt(jp string, fn interface{}) *IngressStatusD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressStatusDie) DieWith(fn func(d *IngressStatusDie)) *IngressStatusDie {
+	nd := IngressStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *IngressStatusDie) DeepCopy() *IngressStatusDie {
 	r := *d.r.DeepCopy()
@@ -1957,6 +2027,13 @@ func (d *IngressLoadBalancerStatusDie) DieStampAt(jp string, fn interface{}) *In
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressLoadBalancerStatusDie) DieWith(fn func(d *IngressLoadBalancerStatusDie)) *IngressLoadBalancerStatusDie {
+	nd := IngressLoadBalancerStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *IngressLoadBalancerStatusDie) DeepCopy() *IngressLoadBalancerStatusDie {
 	r := *d.r.DeepCopy()
@@ -2116,6 +2193,13 @@ func (d *IngressLoadBalancerIngressDie) DieStampAt(jp string, fn interface{}) *I
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressLoadBalancerIngressDie) DieWith(fn func(d *IngressLoadBalancerIngressDie)) *IngressLoadBalancerIngressDie {
+	nd := IngressLoadBalancerIngressBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2291,6 +2375,13 @@ func (d *IngressPortStatusDie) DieStampAt(jp string, fn interface{}) *IngressPor
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressPortStatusDie) DieWith(fn func(d *IngressPortStatusDie)) *IngressPortStatusDie {
+	nd := IngressPortStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2481,6 +2572,13 @@ func (d *IngressClassDie) DieStampAt(jp string, fn interface{}) *IngressClassDie
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressClassDie) DieWith(fn func(d *IngressClassDie)) *IngressClassDie {
+	nd := IngressClassBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2705,6 +2803,13 @@ func (d *IngressClassSpecDie) DieStampAt(jp string, fn interface{}) *IngressClas
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressClassSpecDie) DieWith(fn func(d *IngressClassSpecDie)) *IngressClassSpecDie {
+	nd := IngressClassSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *IngressClassSpecDie) DeepCopy() *IngressClassSpecDie {
 	r := *d.r.DeepCopy()
@@ -2871,6 +2976,13 @@ func (d *IngressClassParametersReferenceDie) DieStampAt(jp string, fn interface{
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IngressClassParametersReferenceDie) DieWith(fn func(d *IngressClassParametersReferenceDie)) *IngressClassParametersReferenceDie {
+	nd := IngressClassParametersReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -3075,6 +3187,13 @@ func (d *NetworkPolicyDie) DieStampAt(jp string, fn interface{}) *NetworkPolicyD
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NetworkPolicyDie) DieWith(fn func(d *NetworkPolicyDie)) *NetworkPolicyDie {
+	nd := NetworkPolicyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -3315,6 +3434,13 @@ func (d *NetworkPolicySpecDie) DieStampAt(jp string, fn interface{}) *NetworkPol
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NetworkPolicySpecDie) DieWith(fn func(d *NetworkPolicySpecDie)) *NetworkPolicySpecDie {
+	nd := NetworkPolicySpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NetworkPolicySpecDie) DeepCopy() *NetworkPolicySpecDie {
 	r := *d.r.DeepCopy()
@@ -3497,6 +3623,13 @@ func (d *NetworkPolicyIngressRuleDie) DieStampAt(jp string, fn interface{}) *Net
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NetworkPolicyIngressRuleDie) DieWith(fn func(d *NetworkPolicyIngressRuleDie)) *NetworkPolicyIngressRuleDie {
+	nd := NetworkPolicyIngressRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NetworkPolicyIngressRuleDie) DeepCopy() *NetworkPolicyIngressRuleDie {
 	r := *d.r.DeepCopy()
@@ -3665,6 +3798,13 @@ func (d *NetworkPolicyEgressRuleDie) DieStampAt(jp string, fn interface{}) *Netw
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NetworkPolicyEgressRuleDie) DieWith(fn func(d *NetworkPolicyEgressRuleDie)) *NetworkPolicyEgressRuleDie {
+	nd := NetworkPolicyEgressRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NetworkPolicyEgressRuleDie) DeepCopy() *NetworkPolicyEgressRuleDie {
 	r := *d.r.DeepCopy()
@@ -3831,6 +3971,13 @@ func (d *NetworkPolicyPortDie) DieStampAt(jp string, fn interface{}) *NetworkPol
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NetworkPolicyPortDie) DieWith(fn func(d *NetworkPolicyPortDie)) *NetworkPolicyPortDie {
+	nd := NetworkPolicyPortBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -4022,6 +4169,13 @@ func (d *NetworkPolicyPeerDie) DieStampAt(jp string, fn interface{}) *NetworkPol
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NetworkPolicyPeerDie) DieWith(fn func(d *NetworkPolicyPeerDie)) *NetworkPolicyPeerDie {
+	nd := NetworkPolicyPeerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *NetworkPolicyPeerDie) DeepCopy() *NetworkPolicyPeerDie {
 	r := *d.r.DeepCopy()
@@ -4201,6 +4355,13 @@ func (d *IPBlockDie) DieStampAt(jp string, fn interface{}) *IPBlockDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IPBlockDie) DieWith(fn func(d *IPBlockDie)) *IPBlockDie {
+	nd := IPBlockBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *IPBlockDie) DeepCopy() *IPBlockDie {
 	r := *d.r.DeepCopy()
@@ -4367,6 +4528,13 @@ func (d *NetworkPolicyStatusDie) DieStampAt(jp string, fn interface{}) *NetworkP
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *NetworkPolicyStatusDie) DieWith(fn func(d *NetworkPolicyStatusDie)) *NetworkPolicyStatusDie {
+	nd := NetworkPolicyStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/node/v1/zz_generated.die.go
+++ b/apis/node/v1/zz_generated.die.go
@@ -196,6 +196,13 @@ func (d *RuntimeClassDie) DieStampAt(jp string, fn interface{}) *RuntimeClassDie
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RuntimeClassDie) DieWith(fn func(d *RuntimeClassDie)) *RuntimeClassDie {
+	nd := RuntimeClassBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *RuntimeClassDie) DeepCopy() *RuntimeClassDie {
 	r := *d.r.DeepCopy()
@@ -423,6 +430,13 @@ func (d *OverheadDie) DieStampAt(jp string, fn interface{}) *OverheadDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *OverheadDie) DieWith(fn func(d *OverheadDie)) *OverheadDie {
+	nd := OverheadBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *OverheadDie) DeepCopy() *OverheadDie {
 	r := *d.r.DeepCopy()
@@ -582,6 +596,13 @@ func (d *SchedulingDie) DieStampAt(jp string, fn interface{}) *SchedulingDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SchedulingDie) DieWith(fn func(d *SchedulingDie)) *SchedulingDie {
+	nd := SchedulingBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/policy/v1/zz_generated.die.go
+++ b/apis/policy/v1/zz_generated.die.go
@@ -197,6 +197,13 @@ func (d *PodDisruptionBudgetDie) DieStampAt(jp string, fn interface{}) *PodDisru
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodDisruptionBudgetDie) DieWith(fn func(d *PodDisruptionBudgetDie)) *PodDisruptionBudgetDie {
+	nd := PodDisruptionBudgetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodDisruptionBudgetDie) DeepCopy() *PodDisruptionBudgetDie {
 	r := *d.r.DeepCopy()
@@ -435,6 +442,13 @@ func (d *PodDisruptionBudgetSpecDie) DieStampAt(jp string, fn interface{}) *PodD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodDisruptionBudgetSpecDie) DieWith(fn func(d *PodDisruptionBudgetSpecDie)) *PodDisruptionBudgetSpecDie {
+	nd := PodDisruptionBudgetSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodDisruptionBudgetSpecDie) DeepCopy() *PodDisruptionBudgetSpecDie {
 	r := *d.r.DeepCopy()
@@ -653,6 +667,13 @@ func (d *PodDisruptionBudgetStatusDie) DieStampAt(jp string, fn interface{}) *Po
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodDisruptionBudgetStatusDie) DieWith(fn func(d *PodDisruptionBudgetStatusDie)) *PodDisruptionBudgetStatusDie {
+	nd := PodDisruptionBudgetStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/policy/v1beta1/zz_generated.die.go
+++ b/apis/policy/v1beta1/zz_generated.die.go
@@ -196,6 +196,13 @@ func (d *PodSecurityPolicyDie) DieStampAt(jp string, fn interface{}) *PodSecurit
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodSecurityPolicyDie) DieWith(fn func(d *PodSecurityPolicyDie)) *PodSecurityPolicyDie {
+	nd := PodSecurityPolicyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PodSecurityPolicyDie) DeepCopy() *PodSecurityPolicyDie {
 	r := *d.r.DeepCopy()
@@ -416,6 +423,13 @@ func (d *PodSecurityPolicySpecDie) DieStampAt(jp string, fn interface{}) *PodSec
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PodSecurityPolicySpecDie) DieWith(fn func(d *PodSecurityPolicySpecDie)) *PodSecurityPolicySpecDie {
+	nd := PodSecurityPolicySpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -744,6 +758,13 @@ func (d *HostPortRangeDie) DieStampAt(jp string, fn interface{}) *HostPortRangeD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *HostPortRangeDie) DieWith(fn func(d *HostPortRangeDie)) *HostPortRangeDie {
+	nd := HostPortRangeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *HostPortRangeDie) DeepCopy() *HostPortRangeDie {
 	r := *d.r.DeepCopy()
@@ -910,6 +931,13 @@ func (d *SELinuxStrategyOptionsDie) DieStampAt(jp string, fn interface{}) *SELin
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SELinuxStrategyOptionsDie) DieWith(fn func(d *SELinuxStrategyOptionsDie)) *SELinuxStrategyOptionsDie {
+	nd := SELinuxStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1080,6 +1108,13 @@ func (d *RunAsUserStrategyOptionsDie) DieStampAt(jp string, fn interface{}) *Run
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RunAsUserStrategyOptionsDie) DieWith(fn func(d *RunAsUserStrategyOptionsDie)) *RunAsUserStrategyOptionsDie {
+	nd := RunAsUserStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *RunAsUserStrategyOptionsDie) DeepCopy() *RunAsUserStrategyOptionsDie {
 	r := *d.r.DeepCopy()
@@ -1246,6 +1281,13 @@ func (d *RunAsGroupStrategyOptionsDie) DieStampAt(jp string, fn interface{}) *Ru
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RunAsGroupStrategyOptionsDie) DieWith(fn func(d *RunAsGroupStrategyOptionsDie)) *RunAsGroupStrategyOptionsDie {
+	nd := RunAsGroupStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1416,6 +1458,13 @@ func (d *SupplementalGroupsStrategyOptionsDie) DieStampAt(jp string, fn interfac
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *SupplementalGroupsStrategyOptionsDie) DieWith(fn func(d *SupplementalGroupsStrategyOptionsDie)) *SupplementalGroupsStrategyOptionsDie {
+	nd := SupplementalGroupsStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *SupplementalGroupsStrategyOptionsDie) DeepCopy() *SupplementalGroupsStrategyOptionsDie {
 	r := *d.r.DeepCopy()
@@ -1584,6 +1633,13 @@ func (d *FSGroupStrategyOptionsDie) DieStampAt(jp string, fn interface{}) *FSGro
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *FSGroupStrategyOptionsDie) DieWith(fn func(d *FSGroupStrategyOptionsDie)) *FSGroupStrategyOptionsDie {
+	nd := FSGroupStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *FSGroupStrategyOptionsDie) DeepCopy() *FSGroupStrategyOptionsDie {
 	r := *d.r.DeepCopy()
@@ -1750,6 +1806,13 @@ func (d *AllowedHostPathDie) DieStampAt(jp string, fn interface{}) *AllowedHostP
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AllowedHostPathDie) DieWith(fn func(d *AllowedHostPathDie)) *AllowedHostPathDie {
+	nd := AllowedHostPathBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1922,6 +1985,13 @@ func (d *AllowedFlexVolumeDie) DieStampAt(jp string, fn interface{}) *AllowedFle
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AllowedFlexVolumeDie) DieWith(fn func(d *AllowedFlexVolumeDie)) *AllowedFlexVolumeDie {
+	nd := AllowedFlexVolumeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *AllowedFlexVolumeDie) DeepCopy() *AllowedFlexVolumeDie {
 	r := *d.r.DeepCopy()
@@ -2083,6 +2153,13 @@ func (d *AllowedCSIDriverDie) DieStampAt(jp string, fn interface{}) *AllowedCSID
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *AllowedCSIDriverDie) DieWith(fn func(d *AllowedCSIDriverDie)) *AllowedCSIDriverDie {
+	nd := AllowedCSIDriverBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *AllowedCSIDriverDie) DeepCopy() *AllowedCSIDriverDie {
 	r := *d.r.DeepCopy()
@@ -2242,6 +2319,13 @@ func (d *RuntimeClassStrategyOptionsDie) DieStampAt(jp string, fn interface{}) *
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *RuntimeClassStrategyOptionsDie) DieWith(fn func(d *RuntimeClassStrategyOptionsDie)) *RuntimeClassStrategyOptionsDie {
+	nd := RuntimeClassStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2410,6 +2494,13 @@ func (d *IDRangeDie) DieStampAt(jp string, fn interface{}) *IDRangeDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *IDRangeDie) DieWith(fn func(d *IDRangeDie)) *IDRangeDie {
+	nd := IDRangeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/scheduling/v1/zz_generated.die.go
+++ b/apis/scheduling/v1/zz_generated.die.go
@@ -196,6 +196,13 @@ func (d *PriorityClassDie) DieStampAt(jp string, fn interface{}) *PriorityClassD
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *PriorityClassDie) DieWith(fn func(d *PriorityClassDie)) *PriorityClassDie {
+	nd := PriorityClassBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *PriorityClassDie) DeepCopy() *PriorityClassDie {
 	r := *d.r.DeepCopy()

--- a/apis/storage/v1/zz_generated.die.go
+++ b/apis/storage/v1/zz_generated.die.go
@@ -197,6 +197,13 @@ func (d *CSIDriverDie) DieStampAt(jp string, fn interface{}) *CSIDriverDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CSIDriverDie) DieWith(fn func(d *CSIDriverDie)) *CSIDriverDie {
+	nd := CSIDriverBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CSIDriverDie) DeepCopy() *CSIDriverDie {
 	r := *d.r.DeepCopy()
@@ -417,6 +424,13 @@ func (d *CSIDriverSpecDie) DieStampAt(jp string, fn interface{}) *CSIDriverSpecD
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CSIDriverSpecDie) DieWith(fn func(d *CSIDriverSpecDie)) *CSIDriverSpecDie {
+	nd := CSIDriverSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -665,6 +679,13 @@ func (d *TokenRequestDie) DieStampAt(jp string, fn interface{}) *TokenRequestDie
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *TokenRequestDie) DieWith(fn func(d *TokenRequestDie)) *TokenRequestDie {
+	nd := TokenRequestBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *TokenRequestDie) DeepCopy() *TokenRequestDie {
 	r := *d.r.DeepCopy()
@@ -846,6 +867,13 @@ func (d *CSINodeDie) DieStampAt(jp string, fn interface{}) *CSINodeDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CSINodeDie) DieWith(fn func(d *CSINodeDie)) *CSINodeDie {
+	nd := CSINodeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1070,6 +1098,13 @@ func (d *CSINodeSpecDie) DieStampAt(jp string, fn interface{}) *CSINodeSpecDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CSINodeSpecDie) DieWith(fn func(d *CSINodeSpecDie)) *CSINodeSpecDie {
+	nd := CSINodeSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CSINodeSpecDie) DeepCopy() *CSINodeSpecDie {
 	r := *d.r.DeepCopy()
@@ -1229,6 +1264,13 @@ func (d *CSINodeDriverDie) DieStampAt(jp string, fn interface{}) *CSINodeDriverD
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CSINodeDriverDie) DieWith(fn func(d *CSINodeDriverDie)) *CSINodeDriverDie {
+	nd := CSINodeDriverBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1413,6 +1455,13 @@ func (d *VolumeNodeResourcesDie) DieStampAt(jp string, fn interface{}) *VolumeNo
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeNodeResourcesDie) DieWith(fn func(d *VolumeNodeResourcesDie)) *VolumeNodeResourcesDie {
+	nd := VolumeNodeResourcesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *VolumeNodeResourcesDie) DeepCopy() *VolumeNodeResourcesDie {
 	r := *d.r.DeepCopy()
@@ -1587,6 +1636,13 @@ func (d *StorageClassDie) DieStampAt(jp string, fn interface{}) *StorageClassDie
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *StorageClassDie) DieWith(fn func(d *StorageClassDie)) *StorageClassDie {
+	nd := StorageClassBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -1859,6 +1915,13 @@ func (d *VolumeAttachmentDie) DieStampAt(jp string, fn interface{}) *VolumeAttac
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeAttachmentDie) DieWith(fn func(d *VolumeAttachmentDie)) *VolumeAttachmentDie {
+	nd := VolumeAttachmentBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *VolumeAttachmentDie) DeepCopy() *VolumeAttachmentDie {
 	r := *d.r.DeepCopy()
@@ -2097,6 +2160,13 @@ func (d *VolumeAttachmentSpecDie) DieStampAt(jp string, fn interface{}) *VolumeA
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeAttachmentSpecDie) DieWith(fn func(d *VolumeAttachmentSpecDie)) *VolumeAttachmentSpecDie {
+	nd := VolumeAttachmentSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *VolumeAttachmentSpecDie) DeepCopy() *VolumeAttachmentSpecDie {
 	r := *d.r.DeepCopy()
@@ -2272,6 +2342,13 @@ func (d *VolumeAttachmentSourceDie) DieStampAt(jp string, fn interface{}) *Volum
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeAttachmentSourceDie) DieWith(fn func(d *VolumeAttachmentSourceDie)) *VolumeAttachmentSourceDie {
+	nd := VolumeAttachmentSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *VolumeAttachmentSourceDie) DeepCopy() *VolumeAttachmentSourceDie {
 	r := *d.r.DeepCopy()
@@ -2438,6 +2515,13 @@ func (d *VolumeAttachmentStatusDie) DieStampAt(jp string, fn interface{}) *Volum
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeAttachmentStatusDie) DieWith(fn func(d *VolumeAttachmentStatusDie)) *VolumeAttachmentStatusDie {
+	nd := VolumeAttachmentStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
@@ -2620,6 +2704,13 @@ func (d *VolumeErrorDie) DieStampAt(jp string, fn interface{}) *VolumeErrorDie {
 			reflectx.ValueOf(fn).Call(args)
 		}
 	})
+}
+
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *VolumeErrorDie) DieWith(fn func(d *VolumeErrorDie)) *VolumeErrorDie {
+	nd := VolumeErrorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
 }
 
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.

--- a/apis/storage/v1beta1/zz_generated.die.go
+++ b/apis/storage/v1beta1/zz_generated.die.go
@@ -197,6 +197,13 @@ func (d *CSIStorageCapacityDie) DieStampAt(jp string, fn interface{}) *CSIStorag
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *CSIStorageCapacityDie) DieWith(fn func(d *CSIStorageCapacityDie)) *CSIStorageCapacityDie {
+	nd := CSIStorageCapacityBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *CSIStorageCapacityDie) DeepCopy() *CSIStorageCapacityDie {
 	r := *d.r.DeepCopy()

--- a/diegen/die/traverse.go
+++ b/diegen/die/traverse.go
@@ -207,6 +207,7 @@ func (c *copyMethodMaker) generateDieFor(die Die) {
 	c.generateDieFeedMethodFor(die)
 	c.generateDieReleaseMethodFor(die)
 	c.generateDieStampMethodFor(die)
+	c.generateDieWithMethodFor(die)
 	c.generateDeepCopyMethodFor(die)
 
 	c.test.generateMissingFieldTestFor(die)
@@ -389,6 +390,16 @@ func (c *copyMethodMaker) generateDieStampMethodFor(die Die) {
 	c.Linef("			%s(fn).Call(args)", c.AliasedRef("reflect", "ValueOf"))
 	c.Linef("		}")
 	c.Linef("	})")
+	c.Linef("}")
+}
+
+func (c *copyMethodMaker) generateDieWithMethodFor(die Die) {
+	c.Linef("")
+	c.Linef("// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.")
+	c.Linef("func (d *%s) DieWith(fn func(d *%s)) *%s {", die.Type, die.Type, die.Type)
+	c.Linef("	nd := %s.DieFeed(d.DieRelease()).DieImmutable(false)", die.Blank)
+	c.Linef("	fn(nd)")
+	c.Linef("	return d.DieFeed(nd.DieRelease())")
 	c.Linef("}")
 }
 

--- a/testing/sandbox/zz_generated.die.go
+++ b/testing/sandbox/zz_generated.die.go
@@ -176,6 +176,13 @@ func (d *DirectDie) DieStampAt(jp string, fn interface{}) *DirectDie {
 	})
 }
 
+// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
+func (d *DirectDie) DieWith(fn func(d *DirectDie)) *DirectDie {
+	nd := DirectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
+	fn(nd)
+	return d.DieFeed(nd.DieRelease())
+}
+
 // DeepCopy returns a new die with equivalent state. Useful for snapshotting a mutable die.
 func (d *DirectDie) DeepCopy() *DirectDie {
 	r := *d.r.DeepCopy()


### PR DESCRIPTION
DieWith passes the current die to a callback function as a mutable die. This is usefull to apply predefined functions that operate on the die while preserving the fluent nature of the api.