### PR TITLE
Allow DieWith to accept multiple funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ type MyResourceDie interface {
 
     // DieWith returns a new die after passing the current die to the callback
     // function. The passed die is mutable.
-    DieWith(fn func(d *MyResourceDie)) *MyResourceDie
+    DieWith(fn ...func(d *MyResourceDie)) *MyResourceDie
 
     // DeepCopy returns a new die with equivalent state. Useful for
     // snapshotting a mutable die.

--- a/apis/admission/v1/zz_generated.die.go
+++ b/apis/admission/v1/zz_generated.die.go
@@ -198,9 +198,13 @@ func (d *AdmissionRequestDie) DieStampAt(jp string, fn interface{}) *AdmissionRe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AdmissionRequestDie) DieWith(fn func(d *AdmissionRequestDie)) *AdmissionRequestDie {
+func (d *AdmissionRequestDie) DieWith(fns ...func(d *AdmissionRequestDie)) *AdmissionRequestDie {
 	nd := AdmissionRequestBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -489,9 +493,13 @@ func (d *AdmissionResponseDie) DieStampAt(jp string, fn interface{}) *AdmissionR
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AdmissionResponseDie) DieWith(fn func(d *AdmissionResponseDie)) *AdmissionResponseDie {
+func (d *AdmissionResponseDie) DieWith(fns ...func(d *AdmissionResponseDie)) *AdmissionResponseDie {
 	nd := AdmissionResponseBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -716,9 +724,13 @@ func (d *AdmissionReviewDie) DieStampAt(jp string, fn interface{}) *AdmissionRev
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AdmissionReviewDie) DieWith(fn func(d *AdmissionReviewDie)) *AdmissionReviewDie {
+func (d *AdmissionReviewDie) DieWith(fns ...func(d *AdmissionReviewDie)) *AdmissionReviewDie {
 	nd := AdmissionReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/admissionregistration/v1/zz_generated.die.go
+++ b/apis/admissionregistration/v1/zz_generated.die.go
@@ -199,9 +199,13 @@ func (d *WebhookClientConfigDie) DieStampAt(jp string, fn interface{}) *WebhookC
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *WebhookClientConfigDie) DieWith(fn func(d *WebhookClientConfigDie)) *WebhookClientConfigDie {
+func (d *WebhookClientConfigDie) DieWith(fns ...func(d *WebhookClientConfigDie)) *WebhookClientConfigDie {
 	nd := WebhookClientConfigBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -410,9 +414,13 @@ func (d *ServiceReferenceDie) DieStampAt(jp string, fn interface{}) *ServiceRefe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServiceReferenceDie) DieWith(fn func(d *ServiceReferenceDie)) *ServiceReferenceDie {
+func (d *ServiceReferenceDie) DieWith(fns ...func(d *ServiceReferenceDie)) *ServiceReferenceDie {
 	nd := ServiceReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -616,9 +624,13 @@ func (d *RuleWithOperationsDie) DieStampAt(jp string, fn interface{}) *RuleWithO
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RuleWithOperationsDie) DieWith(fn func(d *RuleWithOperationsDie)) *RuleWithOperationsDie {
+func (d *RuleWithOperationsDie) DieWith(fns ...func(d *RuleWithOperationsDie)) *RuleWithOperationsDie {
 	nd := RuleWithOperationsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -808,9 +820,13 @@ func (d *RuleDie) DieStampAt(jp string, fn interface{}) *RuleDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RuleDie) DieWith(fn func(d *RuleDie)) *RuleDie {
+func (d *RuleDie) DieWith(fns ...func(d *RuleDie)) *RuleDie {
 	nd := RuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1020,9 +1036,13 @@ func (d *MatchConditionDie) DieStampAt(jp string, fn interface{}) *MatchConditio
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *MatchConditionDie) DieWith(fn func(d *MatchConditionDie)) *MatchConditionDie {
+func (d *MatchConditionDie) DieWith(fns ...func(d *MatchConditionDie)) *MatchConditionDie {
 	nd := MatchConditionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1233,9 +1253,13 @@ func (d *MutatingWebhookConfigurationDie) DieStampAt(jp string, fn interface{}) 
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *MutatingWebhookConfigurationDie) DieWith(fn func(d *MutatingWebhookConfigurationDie)) *MutatingWebhookConfigurationDie {
+func (d *MutatingWebhookConfigurationDie) DieWith(fns ...func(d *MutatingWebhookConfigurationDie)) *MutatingWebhookConfigurationDie {
 	nd := MutatingWebhookConfigurationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1470,9 +1494,13 @@ func (d *MutatingWebhookDie) DieStampAt(jp string, fn interface{}) *MutatingWebh
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *MutatingWebhookDie) DieWith(fn func(d *MutatingWebhookDie)) *MutatingWebhookDie {
+func (d *MutatingWebhookDie) DieWith(fns ...func(d *MutatingWebhookDie)) *MutatingWebhookDie {
 	nd := MutatingWebhookBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1771,9 +1799,13 @@ func (d *ValidatingWebhookConfigurationDie) DieStampAt(jp string, fn interface{}
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ValidatingWebhookConfigurationDie) DieWith(fn func(d *ValidatingWebhookConfigurationDie)) *ValidatingWebhookConfigurationDie {
+func (d *ValidatingWebhookConfigurationDie) DieWith(fns ...func(d *ValidatingWebhookConfigurationDie)) *ValidatingWebhookConfigurationDie {
 	nd := ValidatingWebhookConfigurationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2008,9 +2040,13 @@ func (d *ValidatingWebhookDie) DieStampAt(jp string, fn interface{}) *Validating
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ValidatingWebhookDie) DieWith(fn func(d *ValidatingWebhookDie)) *ValidatingWebhookDie {
+func (d *ValidatingWebhookDie) DieWith(fns ...func(d *ValidatingWebhookDie)) *ValidatingWebhookDie {
 	nd := ValidatingWebhookBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/apiextensions/v1/zz_generated.die.go
+++ b/apis/apiextensions/v1/zz_generated.die.go
@@ -213,9 +213,13 @@ func (d *CustomResourceDefinitionDie) DieStampAt(jp string, fn interface{}) *Cus
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CustomResourceDefinitionDie) DieWith(fn func(d *CustomResourceDefinitionDie)) *CustomResourceDefinitionDie {
+func (d *CustomResourceDefinitionDie) DieWith(fns ...func(d *CustomResourceDefinitionDie)) *CustomResourceDefinitionDie {
 	nd := CustomResourceDefinitionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -475,9 +479,13 @@ func (d *CustomResourceDefinitionSpecDie) DieStampAt(jp string, fn interface{}) 
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CustomResourceDefinitionSpecDie) DieWith(fn func(d *CustomResourceDefinitionSpecDie)) *CustomResourceDefinitionSpecDie {
+func (d *CustomResourceDefinitionSpecDie) DieWith(fns ...func(d *CustomResourceDefinitionSpecDie)) *CustomResourceDefinitionSpecDie {
 	nd := CustomResourceDefinitionSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -695,9 +703,13 @@ func (d *CustomResourceDefinitionVersionDie) DieStampAt(jp string, fn interface{
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CustomResourceDefinitionVersionDie) DieWith(fn func(d *CustomResourceDefinitionVersionDie)) *CustomResourceDefinitionVersionDie {
+func (d *CustomResourceDefinitionVersionDie) DieWith(fns ...func(d *CustomResourceDefinitionVersionDie)) *CustomResourceDefinitionVersionDie {
 	nd := CustomResourceDefinitionVersionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -929,9 +941,13 @@ func (d *CustomResourceValidationDie) DieStampAt(jp string, fn interface{}) *Cus
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CustomResourceValidationDie) DieWith(fn func(d *CustomResourceValidationDie)) *CustomResourceValidationDie {
+func (d *CustomResourceValidationDie) DieWith(fns ...func(d *CustomResourceValidationDie)) *CustomResourceValidationDie {
 	nd := CustomResourceValidationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1114,9 +1130,13 @@ func (d *CustomResourceSubresourcesDie) DieStampAt(jp string, fn interface{}) *C
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CustomResourceSubresourcesDie) DieWith(fn func(d *CustomResourceSubresourcesDie)) *CustomResourceSubresourcesDie {
+func (d *CustomResourceSubresourcesDie) DieWith(fns ...func(d *CustomResourceSubresourcesDie)) *CustomResourceSubresourcesDie {
 	nd := CustomResourceSubresourcesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1306,9 +1326,13 @@ func (d *CustomResourceSubresourceScaleDie) DieStampAt(jp string, fn interface{}
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CustomResourceSubresourceScaleDie) DieWith(fn func(d *CustomResourceSubresourceScaleDie)) *CustomResourceSubresourceScaleDie {
+func (d *CustomResourceSubresourceScaleDie) DieWith(fns ...func(d *CustomResourceSubresourceScaleDie)) *CustomResourceSubresourceScaleDie {
 	nd := CustomResourceSubresourceScaleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1505,9 +1529,13 @@ func (d *CustomResourceColumnDefinitionDie) DieStampAt(jp string, fn interface{}
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CustomResourceColumnDefinitionDie) DieWith(fn func(d *CustomResourceColumnDefinitionDie)) *CustomResourceColumnDefinitionDie {
+func (d *CustomResourceColumnDefinitionDie) DieWith(fns ...func(d *CustomResourceColumnDefinitionDie)) *CustomResourceColumnDefinitionDie {
 	nd := CustomResourceColumnDefinitionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1725,9 +1753,13 @@ func (d *CustomResourceConversionDie) DieStampAt(jp string, fn interface{}) *Cus
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CustomResourceConversionDie) DieWith(fn func(d *CustomResourceConversionDie)) *CustomResourceConversionDie {
+func (d *CustomResourceConversionDie) DieWith(fns ...func(d *CustomResourceConversionDie)) *CustomResourceConversionDie {
 	nd := CustomResourceConversionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1917,9 +1949,13 @@ func (d *WebhookConversionDie) DieStampAt(jp string, fn interface{}) *WebhookCon
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *WebhookConversionDie) DieWith(fn func(d *WebhookConversionDie)) *WebhookConversionDie {
+func (d *WebhookConversionDie) DieWith(fns ...func(d *WebhookConversionDie)) *WebhookConversionDie {
 	nd := WebhookConversionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2109,9 +2145,13 @@ func (d *WebhookClientConfigDie) DieStampAt(jp string, fn interface{}) *WebhookC
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *WebhookClientConfigDie) DieWith(fn func(d *WebhookClientConfigDie)) *WebhookClientConfigDie {
+func (d *WebhookClientConfigDie) DieWith(fns ...func(d *WebhookClientConfigDie)) *WebhookClientConfigDie {
 	nd := WebhookClientConfigBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2320,9 +2360,13 @@ func (d *ServiceReferenceDie) DieStampAt(jp string, fn interface{}) *ServiceRefe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServiceReferenceDie) DieWith(fn func(d *ServiceReferenceDie)) *ServiceReferenceDie {
+func (d *ServiceReferenceDie) DieWith(fns ...func(d *ServiceReferenceDie)) *ServiceReferenceDie {
 	nd := ServiceReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2526,9 +2570,13 @@ func (d *CustomResourceDefinitionStatusDie) DieStampAt(jp string, fn interface{}
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CustomResourceDefinitionStatusDie) DieWith(fn func(d *CustomResourceDefinitionStatusDie)) *CustomResourceDefinitionStatusDie {
+func (d *CustomResourceDefinitionStatusDie) DieWith(fns ...func(d *CustomResourceDefinitionStatusDie)) *CustomResourceDefinitionStatusDie {
 	nd := CustomResourceDefinitionStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2725,9 +2773,13 @@ func (d *CustomResourceDefinitionNamesDie) DieStampAt(jp string, fn interface{})
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CustomResourceDefinitionNamesDie) DieWith(fn func(d *CustomResourceDefinitionNamesDie)) *CustomResourceDefinitionNamesDie {
+func (d *CustomResourceDefinitionNamesDie) DieWith(fns ...func(d *CustomResourceDefinitionNamesDie)) *CustomResourceDefinitionNamesDie {
 	nd := CustomResourceDefinitionNamesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/apiregistration/v1/zz_generated.die.go
+++ b/apis/apiregistration/v1/zz_generated.die.go
@@ -213,9 +213,13 @@ func (d *APIServiceDie) DieStampAt(jp string, fn interface{}) *APIServiceDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *APIServiceDie) DieWith(fn func(d *APIServiceDie)) *APIServiceDie {
+func (d *APIServiceDie) DieWith(fns ...func(d *APIServiceDie)) *APIServiceDie {
 	nd := APIServiceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -475,9 +479,13 @@ func (d *APIServiceSpecDie) DieStampAt(jp string, fn interface{}) *APIServiceSpe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *APIServiceSpecDie) DieWith(fn func(d *APIServiceSpecDie)) *APIServiceSpecDie {
+func (d *APIServiceSpecDie) DieWith(fns ...func(d *APIServiceSpecDie)) *APIServiceSpecDie {
 	nd := APIServiceSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -702,9 +710,13 @@ func (d *ServiceReferenceDie) DieStampAt(jp string, fn interface{}) *ServiceRefe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServiceReferenceDie) DieWith(fn func(d *ServiceReferenceDie)) *ServiceReferenceDie {
+func (d *ServiceReferenceDie) DieWith(fns ...func(d *ServiceReferenceDie)) *ServiceReferenceDie {
 	nd := ServiceReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -901,9 +913,13 @@ func (d *APIServiceStatusDie) DieStampAt(jp string, fn interface{}) *APIServiceS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *APIServiceStatusDie) DieWith(fn func(d *APIServiceStatusDie)) *APIServiceStatusDie {
+func (d *APIServiceStatusDie) DieWith(fns ...func(d *APIServiceStatusDie)) *APIServiceStatusDie {
 	nd := APIServiceStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/apiserver/flowcontrol/v1beta1/zz_generated.die.go
+++ b/apis/apiserver/flowcontrol/v1beta1/zz_generated.die.go
@@ -213,9 +213,13 @@ func (d *FlowSchemaDie) DieStampAt(jp string, fn interface{}) *FlowSchemaDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *FlowSchemaDie) DieWith(fn func(d *FlowSchemaDie)) *FlowSchemaDie {
+func (d *FlowSchemaDie) DieWith(fns ...func(d *FlowSchemaDie)) *FlowSchemaDie {
 	nd := FlowSchemaBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -475,9 +479,13 @@ func (d *FlowSchemaSpecDie) DieStampAt(jp string, fn interface{}) *FlowSchemaSpe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *FlowSchemaSpecDie) DieWith(fn func(d *FlowSchemaSpecDie)) *FlowSchemaSpecDie {
+func (d *FlowSchemaSpecDie) DieWith(fns ...func(d *FlowSchemaSpecDie)) *FlowSchemaSpecDie {
 	nd := FlowSchemaSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -681,9 +689,13 @@ func (d *FlowSchemaStatusDie) DieStampAt(jp string, fn interface{}) *FlowSchemaS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *FlowSchemaStatusDie) DieWith(fn func(d *FlowSchemaStatusDie)) *FlowSchemaStatusDie {
+func (d *FlowSchemaStatusDie) DieWith(fns ...func(d *FlowSchemaStatusDie)) *FlowSchemaStatusDie {
 	nd := FlowSchemaStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -866,9 +878,13 @@ func (d *PriorityLevelConfigurationReferenceDie) DieStampAt(jp string, fn interf
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PriorityLevelConfigurationReferenceDie) DieWith(fn func(d *PriorityLevelConfigurationReferenceDie)) *PriorityLevelConfigurationReferenceDie {
+func (d *PriorityLevelConfigurationReferenceDie) DieWith(fns ...func(d *PriorityLevelConfigurationReferenceDie)) *PriorityLevelConfigurationReferenceDie {
 	nd := PriorityLevelConfigurationReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1051,9 +1067,13 @@ func (d *FlowDistinguisherMethodDie) DieStampAt(jp string, fn interface{}) *Flow
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *FlowDistinguisherMethodDie) DieWith(fn func(d *FlowDistinguisherMethodDie)) *FlowDistinguisherMethodDie {
+func (d *FlowDistinguisherMethodDie) DieWith(fns ...func(d *FlowDistinguisherMethodDie)) *FlowDistinguisherMethodDie {
 	nd := FlowDistinguisherMethodBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1236,9 +1256,13 @@ func (d *PolicyRulesWithSubjectsDie) DieStampAt(jp string, fn interface{}) *Poli
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PolicyRulesWithSubjectsDie) DieWith(fn func(d *PolicyRulesWithSubjectsDie)) *PolicyRulesWithSubjectsDie {
+func (d *PolicyRulesWithSubjectsDie) DieWith(fns ...func(d *PolicyRulesWithSubjectsDie)) *PolicyRulesWithSubjectsDie {
 	nd := PolicyRulesWithSubjectsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1435,9 +1459,13 @@ func (d *SubjectDie) DieStampAt(jp string, fn interface{}) *SubjectDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SubjectDie) DieWith(fn func(d *SubjectDie)) *SubjectDie {
+func (d *SubjectDie) DieWith(fns ...func(d *SubjectDie)) *SubjectDie {
 	nd := SubjectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1641,9 +1669,13 @@ func (d *UserSubjectDie) DieStampAt(jp string, fn interface{}) *UserSubjectDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *UserSubjectDie) DieWith(fn func(d *UserSubjectDie)) *UserSubjectDie {
+func (d *UserSubjectDie) DieWith(fns ...func(d *UserSubjectDie)) *UserSubjectDie {
 	nd := UserSubjectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1826,9 +1858,13 @@ func (d *GroupSubjectDie) DieStampAt(jp string, fn interface{}) *GroupSubjectDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GroupSubjectDie) DieWith(fn func(d *GroupSubjectDie)) *GroupSubjectDie {
+func (d *GroupSubjectDie) DieWith(fns ...func(d *GroupSubjectDie)) *GroupSubjectDie {
 	nd := GroupSubjectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2011,9 +2047,13 @@ func (d *ServiceAccountSubjectDie) DieStampAt(jp string, fn interface{}) *Servic
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServiceAccountSubjectDie) DieWith(fn func(d *ServiceAccountSubjectDie)) *ServiceAccountSubjectDie {
+func (d *ServiceAccountSubjectDie) DieWith(fns ...func(d *ServiceAccountSubjectDie)) *ServiceAccountSubjectDie {
 	nd := ServiceAccountSubjectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2203,9 +2243,13 @@ func (d *ResourcePolicyRuleDie) DieStampAt(jp string, fn interface{}) *ResourceP
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ResourcePolicyRuleDie) DieWith(fn func(d *ResourcePolicyRuleDie)) *ResourcePolicyRuleDie {
+func (d *ResourcePolicyRuleDie) DieWith(fns ...func(d *ResourcePolicyRuleDie)) *ResourcePolicyRuleDie {
 	nd := ResourcePolicyRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2416,9 +2460,13 @@ func (d *NonResourcePolicyRuleDie) DieStampAt(jp string, fn interface{}) *NonRes
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NonResourcePolicyRuleDie) DieWith(fn func(d *NonResourcePolicyRuleDie)) *NonResourcePolicyRuleDie {
+func (d *NonResourcePolicyRuleDie) DieWith(fns ...func(d *NonResourcePolicyRuleDie)) *NonResourcePolicyRuleDie {
 	nd := NonResourcePolicyRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2623,9 +2671,13 @@ func (d *PriorityLevelConfigurationDie) DieStampAt(jp string, fn interface{}) *P
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PriorityLevelConfigurationDie) DieWith(fn func(d *PriorityLevelConfigurationDie)) *PriorityLevelConfigurationDie {
+func (d *PriorityLevelConfigurationDie) DieWith(fns ...func(d *PriorityLevelConfigurationDie)) *PriorityLevelConfigurationDie {
 	nd := PriorityLevelConfigurationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2885,9 +2937,13 @@ func (d *PriorityLevelConfigurationSpecDie) DieStampAt(jp string, fn interface{}
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PriorityLevelConfigurationSpecDie) DieWith(fn func(d *PriorityLevelConfigurationSpecDie)) *PriorityLevelConfigurationSpecDie {
+func (d *PriorityLevelConfigurationSpecDie) DieWith(fns ...func(d *PriorityLevelConfigurationSpecDie)) *PriorityLevelConfigurationSpecDie {
 	nd := PriorityLevelConfigurationSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3077,9 +3133,13 @@ func (d *LimitedPriorityLevelConfigurationDie) DieStampAt(jp string, fn interfac
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LimitedPriorityLevelConfigurationDie) DieWith(fn func(d *LimitedPriorityLevelConfigurationDie)) *LimitedPriorityLevelConfigurationDie {
+func (d *LimitedPriorityLevelConfigurationDie) DieWith(fns ...func(d *LimitedPriorityLevelConfigurationDie)) *LimitedPriorityLevelConfigurationDie {
 	nd := LimitedPriorityLevelConfigurationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3293,9 +3353,13 @@ func (d *LimitResponseDie) DieStampAt(jp string, fn interface{}) *LimitResponseD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LimitResponseDie) DieWith(fn func(d *LimitResponseDie)) *LimitResponseDie {
+func (d *LimitResponseDie) DieWith(fns ...func(d *LimitResponseDie)) *LimitResponseDie {
 	nd := LimitResponseBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3485,9 +3549,13 @@ func (d *QueuingConfigurationDie) DieStampAt(jp string, fn interface{}) *Queuing
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *QueuingConfigurationDie) DieWith(fn func(d *QueuingConfigurationDie)) *QueuingConfigurationDie {
+func (d *QueuingConfigurationDie) DieWith(fns ...func(d *QueuingConfigurationDie)) *QueuingConfigurationDie {
 	nd := QueuingConfigurationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3684,9 +3752,13 @@ func (d *PriorityLevelConfigurationStatusDie) DieStampAt(jp string, fn interface
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PriorityLevelConfigurationStatusDie) DieWith(fn func(d *PriorityLevelConfigurationStatusDie)) *PriorityLevelConfigurationStatusDie {
+func (d *PriorityLevelConfigurationStatusDie) DieWith(fns ...func(d *PriorityLevelConfigurationStatusDie)) *PriorityLevelConfigurationStatusDie {
 	nd := PriorityLevelConfigurationStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/apps/v1/zz_generated.die.go
+++ b/apis/apps/v1/zz_generated.die.go
@@ -216,9 +216,13 @@ func (d *ControllerRevisionDie) DieStampAt(jp string, fn interface{}) *Controlle
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ControllerRevisionDie) DieWith(fn func(d *ControllerRevisionDie)) *ControllerRevisionDie {
+func (d *ControllerRevisionDie) DieWith(fns ...func(d *ControllerRevisionDie)) *ControllerRevisionDie {
 	nd := ControllerRevisionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -475,9 +479,13 @@ func (d *DaemonSetDie) DieStampAt(jp string, fn interface{}) *DaemonSetDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DaemonSetDie) DieWith(fn func(d *DaemonSetDie)) *DaemonSetDie {
+func (d *DaemonSetDie) DieWith(fns ...func(d *DaemonSetDie)) *DaemonSetDie {
 	nd := DaemonSetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -737,9 +745,13 @@ func (d *DaemonSetSpecDie) DieStampAt(jp string, fn interface{}) *DaemonSetSpecD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DaemonSetSpecDie) DieWith(fn func(d *DaemonSetSpecDie)) *DaemonSetSpecDie {
+func (d *DaemonSetSpecDie) DieWith(fns ...func(d *DaemonSetSpecDie)) *DaemonSetSpecDie {
 	nd := DaemonSetSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -950,9 +962,13 @@ func (d *DaemonSetUpdateStrategyDie) DieStampAt(jp string, fn interface{}) *Daem
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DaemonSetUpdateStrategyDie) DieWith(fn func(d *DaemonSetUpdateStrategyDie)) *DaemonSetUpdateStrategyDie {
+func (d *DaemonSetUpdateStrategyDie) DieWith(fns ...func(d *DaemonSetUpdateStrategyDie)) *DaemonSetUpdateStrategyDie {
 	nd := DaemonSetUpdateStrategyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1142,9 +1158,13 @@ func (d *RollingUpdateDaemonSetDie) DieStampAt(jp string, fn interface{}) *Rolli
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RollingUpdateDaemonSetDie) DieWith(fn func(d *RollingUpdateDaemonSetDie)) *RollingUpdateDaemonSetDie {
+func (d *RollingUpdateDaemonSetDie) DieWith(fns ...func(d *RollingUpdateDaemonSetDie)) *RollingUpdateDaemonSetDie {
 	nd := RollingUpdateDaemonSetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1362,9 +1382,13 @@ func (d *DaemonSetStatusDie) DieStampAt(jp string, fn interface{}) *DaemonSetSta
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DaemonSetStatusDie) DieWith(fn func(d *DaemonSetStatusDie)) *DaemonSetStatusDie {
+func (d *DaemonSetStatusDie) DieWith(fns ...func(d *DaemonSetStatusDie)) *DaemonSetStatusDie {
 	nd := DaemonSetStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1625,9 +1649,13 @@ func (d *DeploymentDie) DieStampAt(jp string, fn interface{}) *DeploymentDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DeploymentDie) DieWith(fn func(d *DeploymentDie)) *DeploymentDie {
+func (d *DeploymentDie) DieWith(fns ...func(d *DeploymentDie)) *DeploymentDie {
 	nd := DeploymentBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1887,9 +1915,13 @@ func (d *DeploymentSpecDie) DieStampAt(jp string, fn interface{}) *DeploymentSpe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DeploymentSpecDie) DieWith(fn func(d *DeploymentSpecDie)) *DeploymentSpecDie {
+func (d *DeploymentSpecDie) DieWith(fns ...func(d *DeploymentSpecDie)) *DeploymentSpecDie {
 	nd := DeploymentSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2121,9 +2153,13 @@ func (d *DeploymentStrategyDie) DieStampAt(jp string, fn interface{}) *Deploymen
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DeploymentStrategyDie) DieWith(fn func(d *DeploymentStrategyDie)) *DeploymentStrategyDie {
+func (d *DeploymentStrategyDie) DieWith(fns ...func(d *DeploymentStrategyDie)) *DeploymentStrategyDie {
 	nd := DeploymentStrategyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2313,9 +2349,13 @@ func (d *RollingUpdateDeploymentDie) DieStampAt(jp string, fn interface{}) *Roll
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RollingUpdateDeploymentDie) DieWith(fn func(d *RollingUpdateDeploymentDie)) *RollingUpdateDeploymentDie {
+func (d *RollingUpdateDeploymentDie) DieWith(fns ...func(d *RollingUpdateDeploymentDie)) *RollingUpdateDeploymentDie {
 	nd := RollingUpdateDeploymentBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2533,9 +2573,13 @@ func (d *DeploymentStatusDie) DieStampAt(jp string, fn interface{}) *DeploymentS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DeploymentStatusDie) DieWith(fn func(d *DeploymentStatusDie)) *DeploymentStatusDie {
+func (d *DeploymentStatusDie) DieWith(fns ...func(d *DeploymentStatusDie)) *DeploymentStatusDie {
 	nd := DeploymentStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2782,9 +2826,13 @@ func (d *ReplicaSetDie) DieStampAt(jp string, fn interface{}) *ReplicaSetDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ReplicaSetDie) DieWith(fn func(d *ReplicaSetDie)) *ReplicaSetDie {
+func (d *ReplicaSetDie) DieWith(fns ...func(d *ReplicaSetDie)) *ReplicaSetDie {
 	nd := ReplicaSetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3044,9 +3092,13 @@ func (d *ReplicaSetSpecDie) DieStampAt(jp string, fn interface{}) *ReplicaSetSpe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ReplicaSetSpecDie) DieWith(fn func(d *ReplicaSetSpecDie)) *ReplicaSetSpecDie {
+func (d *ReplicaSetSpecDie) DieWith(fns ...func(d *ReplicaSetSpecDie)) *ReplicaSetSpecDie {
 	nd := ReplicaSetSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3250,9 +3302,13 @@ func (d *ReplicaSetStatusDie) DieStampAt(jp string, fn interface{}) *ReplicaSetS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ReplicaSetStatusDie) DieWith(fn func(d *ReplicaSetStatusDie)) *ReplicaSetStatusDie {
+func (d *ReplicaSetStatusDie) DieWith(fns ...func(d *ReplicaSetStatusDie)) *ReplicaSetStatusDie {
 	nd := ReplicaSetStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3485,9 +3541,13 @@ func (d *StatefulSetDie) DieStampAt(jp string, fn interface{}) *StatefulSetDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StatefulSetDie) DieWith(fn func(d *StatefulSetDie)) *StatefulSetDie {
+func (d *StatefulSetDie) DieWith(fns ...func(d *StatefulSetDie)) *StatefulSetDie {
 	nd := StatefulSetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3747,9 +3807,13 @@ func (d *StatefulSetSpecDie) DieStampAt(jp string, fn interface{}) *StatefulSetS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StatefulSetSpecDie) DieWith(fn func(d *StatefulSetSpecDie)) *StatefulSetSpecDie {
+func (d *StatefulSetSpecDie) DieWith(fns ...func(d *StatefulSetSpecDie)) *StatefulSetSpecDie {
 	nd := StatefulSetSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4002,9 +4066,13 @@ func (d *StatefulSetUpdateStrategyDie) DieStampAt(jp string, fn interface{}) *St
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StatefulSetUpdateStrategyDie) DieWith(fn func(d *StatefulSetUpdateStrategyDie)) *StatefulSetUpdateStrategyDie {
+func (d *StatefulSetUpdateStrategyDie) DieWith(fns ...func(d *StatefulSetUpdateStrategyDie)) *StatefulSetUpdateStrategyDie {
 	nd := StatefulSetUpdateStrategyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4194,9 +4262,13 @@ func (d *RollingUpdateStatefulSetStrategyDie) DieStampAt(jp string, fn interface
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RollingUpdateStatefulSetStrategyDie) DieWith(fn func(d *RollingUpdateStatefulSetStrategyDie)) *RollingUpdateStatefulSetStrategyDie {
+func (d *RollingUpdateStatefulSetStrategyDie) DieWith(fns ...func(d *RollingUpdateStatefulSetStrategyDie)) *RollingUpdateStatefulSetStrategyDie {
 	nd := RollingUpdateStatefulSetStrategyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4400,9 +4472,13 @@ func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieStampAt(jp strin
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieWith(fn func(d *StatefulSetPersistentVolumeClaimRetentionPolicyDie)) *StatefulSetPersistentVolumeClaimRetentionPolicyDie {
+func (d *StatefulSetPersistentVolumeClaimRetentionPolicyDie) DieWith(fns ...func(d *StatefulSetPersistentVolumeClaimRetentionPolicyDie)) *StatefulSetPersistentVolumeClaimRetentionPolicyDie {
 	nd := StatefulSetPersistentVolumeClaimRetentionPolicyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4592,9 +4668,13 @@ func (d *StatefulSetOrdinalsDie) DieStampAt(jp string, fn interface{}) *Stateful
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StatefulSetOrdinalsDie) DieWith(fn func(d *StatefulSetOrdinalsDie)) *StatefulSetOrdinalsDie {
+func (d *StatefulSetOrdinalsDie) DieWith(fns ...func(d *StatefulSetOrdinalsDie)) *StatefulSetOrdinalsDie {
 	nd := StatefulSetOrdinalsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4777,9 +4857,13 @@ func (d *StatefulSetStatusDie) DieStampAt(jp string, fn interface{}) *StatefulSe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StatefulSetStatusDie) DieWith(fn func(d *StatefulSetStatusDie)) *StatefulSetStatusDie {
+func (d *StatefulSetStatusDie) DieWith(fns ...func(d *StatefulSetStatusDie)) *StatefulSetStatusDie {
 	nd := StatefulSetStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/authentication/v1/zz_generated.die.go
+++ b/apis/authentication/v1/zz_generated.die.go
@@ -215,9 +215,13 @@ func (d *TokenReviewDie) DieStampAt(jp string, fn interface{}) *TokenReviewDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TokenReviewDie) DieWith(fn func(d *TokenReviewDie)) *TokenReviewDie {
+func (d *TokenReviewDie) DieWith(fns ...func(d *TokenReviewDie)) *TokenReviewDie {
 	nd := TokenReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -459,9 +463,13 @@ func (d *TokenRequestSpecDie) DieStampAt(jp string, fn interface{}) *TokenReques
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TokenRequestSpecDie) DieWith(fn func(d *TokenRequestSpecDie)) *TokenRequestSpecDie {
+func (d *TokenRequestSpecDie) DieWith(fns ...func(d *TokenRequestSpecDie)) *TokenRequestSpecDie {
 	nd := TokenRequestSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -658,9 +666,13 @@ func (d *BoundObjectReferenceDie) DieStampAt(jp string, fn interface{}) *BoundOb
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *BoundObjectReferenceDie) DieWith(fn func(d *BoundObjectReferenceDie)) *BoundObjectReferenceDie {
+func (d *BoundObjectReferenceDie) DieWith(fns ...func(d *BoundObjectReferenceDie)) *BoundObjectReferenceDie {
 	nd := BoundObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -864,9 +876,13 @@ func (d *TokenRequestStatusDie) DieStampAt(jp string, fn interface{}) *TokenRequ
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TokenRequestStatusDie) DieWith(fn func(d *TokenRequestStatusDie)) *TokenRequestStatusDie {
+func (d *TokenRequestStatusDie) DieWith(fns ...func(d *TokenRequestStatusDie)) *TokenRequestStatusDie {
 	nd := TokenRequestStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1056,9 +1072,13 @@ func (d *UserInfoDie) DieStampAt(jp string, fn interface{}) *UserInfoDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *UserInfoDie) DieWith(fn func(d *UserInfoDie)) *UserInfoDie {
+func (d *UserInfoDie) DieWith(fns ...func(d *UserInfoDie)) *UserInfoDie {
 	nd := UserInfoBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/authorization/rbac/v1/zz_generated.die.go
+++ b/apis/authorization/rbac/v1/zz_generated.die.go
@@ -214,9 +214,13 @@ func (d *ClusterRoleDie) DieStampAt(jp string, fn interface{}) *ClusterRoleDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ClusterRoleDie) DieWith(fn func(d *ClusterRoleDie)) *ClusterRoleDie {
+func (d *ClusterRoleDie) DieWith(fns ...func(d *ClusterRoleDie)) *ClusterRoleDie {
 	nd := ClusterRoleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -458,9 +462,13 @@ func (d *AggregationRuleDie) DieStampAt(jp string, fn interface{}) *AggregationR
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AggregationRuleDie) DieWith(fn func(d *AggregationRuleDie)) *AggregationRuleDie {
+func (d *AggregationRuleDie) DieWith(fns ...func(d *AggregationRuleDie)) *AggregationRuleDie {
 	nd := AggregationRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -658,9 +666,13 @@ func (d *ClusterRoleBindingDie) DieStampAt(jp string, fn interface{}) *ClusterRo
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ClusterRoleBindingDie) DieWith(fn func(d *ClusterRoleBindingDie)) *ClusterRoleBindingDie {
+func (d *ClusterRoleBindingDie) DieWith(fns ...func(d *ClusterRoleBindingDie)) *ClusterRoleBindingDie {
 	nd := ClusterRoleBindingBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -917,9 +929,13 @@ func (d *RoleDie) DieStampAt(jp string, fn interface{}) *RoleDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RoleDie) DieWith(fn func(d *RoleDie)) *RoleDie {
+func (d *RoleDie) DieWith(fns ...func(d *RoleDie)) *RoleDie {
 	nd := RoleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1154,9 +1170,13 @@ func (d *PolicyRuleDie) DieStampAt(jp string, fn interface{}) *PolicyRuleDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PolicyRuleDie) DieWith(fn func(d *PolicyRuleDie)) *PolicyRuleDie {
+func (d *PolicyRuleDie) DieWith(fns ...func(d *PolicyRuleDie)) *PolicyRuleDie {
 	nd := PolicyRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1382,9 +1402,13 @@ func (d *RoleBindingDie) DieStampAt(jp string, fn interface{}) *RoleBindingDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RoleBindingDie) DieWith(fn func(d *RoleBindingDie)) *RoleBindingDie {
+func (d *RoleBindingDie) DieWith(fns ...func(d *RoleBindingDie)) *RoleBindingDie {
 	nd := RoleBindingBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1626,9 +1650,13 @@ func (d *SubjectDie) DieStampAt(jp string, fn interface{}) *SubjectDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SubjectDie) DieWith(fn func(d *SubjectDie)) *SubjectDie {
+func (d *SubjectDie) DieWith(fns ...func(d *SubjectDie)) *SubjectDie {
 	nd := SubjectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1832,9 +1860,13 @@ func (d *RoleRefDie) DieStampAt(jp string, fn interface{}) *RoleRefDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RoleRefDie) DieWith(fn func(d *RoleRefDie)) *RoleRefDie {
+func (d *RoleRefDie) DieWith(fns ...func(d *RoleRefDie)) *RoleRefDie {
 	nd := RoleRefBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/authorization/v1/zz_generated.die.go
+++ b/apis/authorization/v1/zz_generated.die.go
@@ -213,9 +213,13 @@ func (d *LocalSubjectAccessReviewDie) DieStampAt(jp string, fn interface{}) *Loc
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LocalSubjectAccessReviewDie) DieWith(fn func(d *LocalSubjectAccessReviewDie)) *LocalSubjectAccessReviewDie {
+func (d *LocalSubjectAccessReviewDie) DieWith(fns ...func(d *LocalSubjectAccessReviewDie)) *LocalSubjectAccessReviewDie {
 	nd := LocalSubjectAccessReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -472,9 +476,13 @@ func (d *SelfSubjectAccessReviewDie) DieStampAt(jp string, fn interface{}) *Self
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SelfSubjectAccessReviewDie) DieWith(fn func(d *SelfSubjectAccessReviewDie)) *SelfSubjectAccessReviewDie {
+func (d *SelfSubjectAccessReviewDie) DieWith(fns ...func(d *SelfSubjectAccessReviewDie)) *SelfSubjectAccessReviewDie {
 	nd := SelfSubjectAccessReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -734,9 +742,13 @@ func (d *SelfSubjectAccessReviewSpecDie) DieStampAt(jp string, fn interface{}) *
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SelfSubjectAccessReviewSpecDie) DieWith(fn func(d *SelfSubjectAccessReviewSpecDie)) *SelfSubjectAccessReviewSpecDie {
+func (d *SelfSubjectAccessReviewSpecDie) DieWith(fns ...func(d *SelfSubjectAccessReviewSpecDie)) *SelfSubjectAccessReviewSpecDie {
 	nd := SelfSubjectAccessReviewSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -941,9 +953,13 @@ func (d *SelfSubjectRulesReviewDie) DieStampAt(jp string, fn interface{}) *SelfS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SelfSubjectRulesReviewDie) DieWith(fn func(d *SelfSubjectRulesReviewDie)) *SelfSubjectRulesReviewDie {
+func (d *SelfSubjectRulesReviewDie) DieWith(fns ...func(d *SelfSubjectRulesReviewDie)) *SelfSubjectRulesReviewDie {
 	nd := SelfSubjectRulesReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1203,9 +1219,13 @@ func (d *SelfSubjectRulesReviewSpecDie) DieStampAt(jp string, fn interface{}) *S
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SelfSubjectRulesReviewSpecDie) DieWith(fn func(d *SelfSubjectRulesReviewSpecDie)) *SelfSubjectRulesReviewSpecDie {
+func (d *SelfSubjectRulesReviewSpecDie) DieWith(fns ...func(d *SelfSubjectRulesReviewSpecDie)) *SelfSubjectRulesReviewSpecDie {
 	nd := SelfSubjectRulesReviewSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1388,9 +1408,13 @@ func (d *SubjectRulesReviewStatusDie) DieStampAt(jp string, fn interface{}) *Sub
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SubjectRulesReviewStatusDie) DieWith(fn func(d *SubjectRulesReviewStatusDie)) *SubjectRulesReviewStatusDie {
+func (d *SubjectRulesReviewStatusDie) DieWith(fns ...func(d *SubjectRulesReviewStatusDie)) *SubjectRulesReviewStatusDie {
 	nd := SubjectRulesReviewStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1594,9 +1618,13 @@ func (d *ResourceRuleDie) DieStampAt(jp string, fn interface{}) *ResourceRuleDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ResourceRuleDie) DieWith(fn func(d *ResourceRuleDie)) *ResourceRuleDie {
+func (d *ResourceRuleDie) DieWith(fns ...func(d *ResourceRuleDie)) *ResourceRuleDie {
 	nd := ResourceRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1800,9 +1828,13 @@ func (d *NonResourceRuleDie) DieStampAt(jp string, fn interface{}) *NonResourceR
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NonResourceRuleDie) DieWith(fn func(d *NonResourceRuleDie)) *NonResourceRuleDie {
+func (d *NonResourceRuleDie) DieWith(fns ...func(d *NonResourceRuleDie)) *NonResourceRuleDie {
 	nd := NonResourceRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2007,9 +2039,13 @@ func (d *SubjectAccessReviewDie) DieStampAt(jp string, fn interface{}) *SubjectA
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SubjectAccessReviewDie) DieWith(fn func(d *SubjectAccessReviewDie)) *SubjectAccessReviewDie {
+func (d *SubjectAccessReviewDie) DieWith(fns ...func(d *SubjectAccessReviewDie)) *SubjectAccessReviewDie {
 	nd := SubjectAccessReviewBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2269,9 +2305,13 @@ func (d *SubjectAccessReviewSpecDie) DieStampAt(jp string, fn interface{}) *Subj
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SubjectAccessReviewSpecDie) DieWith(fn func(d *SubjectAccessReviewSpecDie)) *SubjectAccessReviewSpecDie {
+func (d *SubjectAccessReviewSpecDie) DieWith(fns ...func(d *SubjectAccessReviewSpecDie)) *SubjectAccessReviewSpecDie {
 	nd := SubjectAccessReviewSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2482,9 +2522,13 @@ func (d *ResourceAttributesDie) DieStampAt(jp string, fn interface{}) *ResourceA
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ResourceAttributesDie) DieWith(fn func(d *ResourceAttributesDie)) *ResourceAttributesDie {
+func (d *ResourceAttributesDie) DieWith(fns ...func(d *ResourceAttributesDie)) *ResourceAttributesDie {
 	nd := ResourceAttributesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2709,9 +2753,13 @@ func (d *NonResourceAttributesDie) DieStampAt(jp string, fn interface{}) *NonRes
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NonResourceAttributesDie) DieWith(fn func(d *NonResourceAttributesDie)) *NonResourceAttributesDie {
+func (d *NonResourceAttributesDie) DieWith(fns ...func(d *NonResourceAttributesDie)) *NonResourceAttributesDie {
 	nd := NonResourceAttributesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2901,9 +2949,13 @@ func (d *SubjectAccessReviewStatusDie) DieStampAt(jp string, fn interface{}) *Su
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SubjectAccessReviewStatusDie) DieWith(fn func(d *SubjectAccessReviewStatusDie)) *SubjectAccessReviewStatusDie {
+func (d *SubjectAccessReviewStatusDie) DieWith(fns ...func(d *SubjectAccessReviewStatusDie)) *SubjectAccessReviewStatusDie {
 	nd := SubjectAccessReviewStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/autoscaling/v1/zz_generated.die.go
+++ b/apis/autoscaling/v1/zz_generated.die.go
@@ -214,9 +214,13 @@ func (d *HorizontalPodAutoscalerDie) DieStampAt(jp string, fn interface{}) *Hori
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *HorizontalPodAutoscalerDie) DieWith(fn func(d *HorizontalPodAutoscalerDie)) *HorizontalPodAutoscalerDie {
+func (d *HorizontalPodAutoscalerDie) DieWith(fns ...func(d *HorizontalPodAutoscalerDie)) *HorizontalPodAutoscalerDie {
 	nd := HorizontalPodAutoscalerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -476,9 +480,13 @@ func (d *HorizontalPodAutoscalerSpecDie) DieStampAt(jp string, fn interface{}) *
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *HorizontalPodAutoscalerSpecDie) DieWith(fn func(d *HorizontalPodAutoscalerSpecDie)) *HorizontalPodAutoscalerSpecDie {
+func (d *HorizontalPodAutoscalerSpecDie) DieWith(fns ...func(d *HorizontalPodAutoscalerSpecDie)) *HorizontalPodAutoscalerSpecDie {
 	nd := HorizontalPodAutoscalerSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -682,9 +690,13 @@ func (d *CrossVersionObjectReferenceDie) DieStampAt(jp string, fn interface{}) *
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CrossVersionObjectReferenceDie) DieWith(fn func(d *CrossVersionObjectReferenceDie)) *CrossVersionObjectReferenceDie {
+func (d *CrossVersionObjectReferenceDie) DieWith(fns ...func(d *CrossVersionObjectReferenceDie)) *CrossVersionObjectReferenceDie {
 	nd := CrossVersionObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -881,9 +893,13 @@ func (d *HorizontalPodAutoscalerStatusDie) DieStampAt(jp string, fn interface{})
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *HorizontalPodAutoscalerStatusDie) DieWith(fn func(d *HorizontalPodAutoscalerStatusDie)) *HorizontalPodAutoscalerStatusDie {
+func (d *HorizontalPodAutoscalerStatusDie) DieWith(fns ...func(d *HorizontalPodAutoscalerStatusDie)) *HorizontalPodAutoscalerStatusDie {
 	nd := HorizontalPodAutoscalerStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/batch/v1/zz_generated.die.go
+++ b/apis/batch/v1/zz_generated.die.go
@@ -216,9 +216,13 @@ func (d *CronJobDie) DieStampAt(jp string, fn interface{}) *CronJobDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CronJobDie) DieWith(fn func(d *CronJobDie)) *CronJobDie {
+func (d *CronJobDie) DieWith(fns ...func(d *CronJobDie)) *CronJobDie {
 	nd := CronJobBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -478,9 +482,13 @@ func (d *CronJobSpecDie) DieStampAt(jp string, fn interface{}) *CronJobSpecDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CronJobSpecDie) DieWith(fn func(d *CronJobSpecDie)) *CronJobSpecDie {
+func (d *CronJobSpecDie) DieWith(fns ...func(d *CronJobSpecDie)) *CronJobSpecDie {
 	nd := CronJobSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -714,9 +722,13 @@ func (d *CronJobStatusDie) DieStampAt(jp string, fn interface{}) *CronJobStatusD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CronJobStatusDie) DieWith(fn func(d *CronJobStatusDie)) *CronJobStatusDie {
+func (d *CronJobStatusDie) DieWith(fns ...func(d *CronJobStatusDie)) *CronJobStatusDie {
 	nd := CronJobStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -928,9 +940,13 @@ func (d *JobDie) DieStampAt(jp string, fn interface{}) *JobDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *JobDie) DieWith(fn func(d *JobDie)) *JobDie {
+func (d *JobDie) DieWith(fns ...func(d *JobDie)) *JobDie {
 	nd := JobBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1190,9 +1206,13 @@ func (d *JobSpecDie) DieStampAt(jp string, fn interface{}) *JobSpecDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *JobSpecDie) DieWith(fn func(d *JobSpecDie)) *JobSpecDie {
+func (d *JobSpecDie) DieWith(fns ...func(d *JobSpecDie)) *JobSpecDie {
 	nd := JobSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1453,9 +1473,13 @@ func (d *PodFailurePolicyDie) DieStampAt(jp string, fn interface{}) *PodFailureP
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodFailurePolicyDie) DieWith(fn func(d *PodFailurePolicyDie)) *PodFailurePolicyDie {
+func (d *PodFailurePolicyDie) DieWith(fns ...func(d *PodFailurePolicyDie)) *PodFailurePolicyDie {
 	nd := PodFailurePolicyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1638,9 +1662,13 @@ func (d *PodFailurePolicyRuleDie) DieStampAt(jp string, fn interface{}) *PodFail
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodFailurePolicyRuleDie) DieWith(fn func(d *PodFailurePolicyRuleDie)) *PodFailurePolicyRuleDie {
+func (d *PodFailurePolicyRuleDie) DieWith(fns ...func(d *PodFailurePolicyRuleDie)) *PodFailurePolicyRuleDie {
 	nd := PodFailurePolicyRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1839,9 +1867,13 @@ func (d *PodFailurePolicyOnExitCodesRequirementDie) DieStampAt(jp string, fn int
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodFailurePolicyOnExitCodesRequirementDie) DieWith(fn func(d *PodFailurePolicyOnExitCodesRequirementDie)) *PodFailurePolicyOnExitCodesRequirementDie {
+func (d *PodFailurePolicyOnExitCodesRequirementDie) DieWith(fns ...func(d *PodFailurePolicyOnExitCodesRequirementDie)) *PodFailurePolicyOnExitCodesRequirementDie {
 	nd := PodFailurePolicyOnExitCodesRequirementBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2040,9 +2072,13 @@ func (d *PodFailurePolicyOnPodConditionsPatternDie) DieStampAt(jp string, fn int
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodFailurePolicyOnPodConditionsPatternDie) DieWith(fn func(d *PodFailurePolicyOnPodConditionsPatternDie)) *PodFailurePolicyOnPodConditionsPatternDie {
+func (d *PodFailurePolicyOnPodConditionsPatternDie) DieWith(fns ...func(d *PodFailurePolicyOnPodConditionsPatternDie)) *PodFailurePolicyOnPodConditionsPatternDie {
 	nd := PodFailurePolicyOnPodConditionsPatternBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2232,9 +2268,13 @@ func (d *JobStatusDie) DieStampAt(jp string, fn interface{}) *JobStatusDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *JobStatusDie) DieWith(fn func(d *JobStatusDie)) *JobStatusDie {
+func (d *JobStatusDie) DieWith(fns ...func(d *JobStatusDie)) *JobStatusDie {
 	nd := JobStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2481,9 +2521,13 @@ func (d *UncountedTerminatedPodsDie) DieStampAt(jp string, fn interface{}) *Unco
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *UncountedTerminatedPodsDie) DieWith(fn func(d *UncountedTerminatedPodsDie)) *UncountedTerminatedPodsDie {
+func (d *UncountedTerminatedPodsDie) DieWith(fns ...func(d *UncountedTerminatedPodsDie)) *UncountedTerminatedPodsDie {
 	nd := UncountedTerminatedPodsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/certificates/v1/zz_generated.die.go
+++ b/apis/certificates/v1/zz_generated.die.go
@@ -213,9 +213,13 @@ func (d *CertificateSigningRequestDie) DieStampAt(jp string, fn interface{}) *Ce
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CertificateSigningRequestDie) DieWith(fn func(d *CertificateSigningRequestDie)) *CertificateSigningRequestDie {
+func (d *CertificateSigningRequestDie) DieWith(fns ...func(d *CertificateSigningRequestDie)) *CertificateSigningRequestDie {
 	nd := CertificateSigningRequestBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -475,9 +479,13 @@ func (d *CertificateSigningRequestSpecDie) DieStampAt(jp string, fn interface{})
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CertificateSigningRequestSpecDie) DieWith(fn func(d *CertificateSigningRequestSpecDie)) *CertificateSigningRequestSpecDie {
+func (d *CertificateSigningRequestSpecDie) DieWith(fns ...func(d *CertificateSigningRequestSpecDie)) *CertificateSigningRequestSpecDie {
 	nd := CertificateSigningRequestSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -724,9 +732,13 @@ func (d *CertificateSigningRequestStatusDie) DieStampAt(jp string, fn interface{
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CertificateSigningRequestStatusDie) DieWith(fn func(d *CertificateSigningRequestStatusDie)) *CertificateSigningRequestStatusDie {
+func (d *CertificateSigningRequestStatusDie) DieWith(fns ...func(d *CertificateSigningRequestStatusDie)) *CertificateSigningRequestStatusDie {
 	nd := CertificateSigningRequestStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/coordination/v1/zz_generated.die.go
+++ b/apis/coordination/v1/zz_generated.die.go
@@ -214,9 +214,13 @@ func (d *LeaseDie) DieStampAt(jp string, fn interface{}) *LeaseDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LeaseDie) DieWith(fn func(d *LeaseDie)) *LeaseDie {
+func (d *LeaseDie) DieWith(fns ...func(d *LeaseDie)) *LeaseDie {
 	nd := LeaseBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -460,9 +464,13 @@ func (d *LeaseSpecDie) DieStampAt(jp string, fn interface{}) *LeaseSpecDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LeaseSpecDie) DieWith(fn func(d *LeaseSpecDie)) *LeaseSpecDie {
+func (d *LeaseSpecDie) DieWith(fns ...func(d *LeaseSpecDie)) *LeaseSpecDie {
 	nd := LeaseSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/core/v1/pod_test.go
+++ b/apis/core/v1/pod_test.go
@@ -459,10 +459,15 @@ func TestPod(t *testing.T) {
 		{
 			name: "with",
 			die: diecorev1.PodBlank.
-				DieWith(func(d *diecorev1.PodDie) {
-					d.APIVersion("v1")
-					d.Kind("Pod")
-				}),
+				DieWith(
+					func(d *diecorev1.PodDie) {
+						d.APIVersion("v1")
+					},
+					nil,
+					func(d *diecorev1.PodDie) {
+						d.Kind("Pod")
+					},
+				),
 			expected: corev1.Pod{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",

--- a/apis/core/v1/zz_generated.die.go
+++ b/apis/core/v1/zz_generated.die.go
@@ -217,9 +217,13 @@ func (d *BindingDie) DieStampAt(jp string, fn interface{}) *BindingDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *BindingDie) DieWith(fn func(d *BindingDie)) *BindingDie {
+func (d *BindingDie) DieWith(fns ...func(d *BindingDie)) *BindingDie {
 	nd := BindingBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -454,9 +458,13 @@ func (d *ObjectReferenceDie) DieStampAt(jp string, fn interface{}) *ObjectRefere
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ObjectReferenceDie) DieWith(fn func(d *ObjectReferenceDie)) *ObjectReferenceDie {
+func (d *ObjectReferenceDie) DieWith(fns ...func(d *ObjectReferenceDie)) *ObjectReferenceDie {
 	nd := ObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -681,9 +689,13 @@ func (d *LocalObjectReferenceDie) DieStampAt(jp string, fn interface{}) *LocalOb
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LocalObjectReferenceDie) DieWith(fn func(d *LocalObjectReferenceDie)) *LocalObjectReferenceDie {
+func (d *LocalObjectReferenceDie) DieWith(fns ...func(d *LocalObjectReferenceDie)) *LocalObjectReferenceDie {
 	nd := LocalObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -866,9 +878,13 @@ func (d *TypedLocalObjectReferenceDie) DieStampAt(jp string, fn interface{}) *Ty
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TypedLocalObjectReferenceDie) DieWith(fn func(d *TypedLocalObjectReferenceDie)) *TypedLocalObjectReferenceDie {
+func (d *TypedLocalObjectReferenceDie) DieWith(fns ...func(d *TypedLocalObjectReferenceDie)) *TypedLocalObjectReferenceDie {
 	nd := TypedLocalObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1065,9 +1081,13 @@ func (d *TypedObjectReferenceDie) DieStampAt(jp string, fn interface{}) *TypedOb
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TypedObjectReferenceDie) DieWith(fn func(d *TypedObjectReferenceDie)) *TypedObjectReferenceDie {
+func (d *TypedObjectReferenceDie) DieWith(fns ...func(d *TypedObjectReferenceDie)) *TypedObjectReferenceDie {
 	nd := TypedObjectReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1271,9 +1291,13 @@ func (d *SecretReferenceDie) DieStampAt(jp string, fn interface{}) *SecretRefere
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SecretReferenceDie) DieWith(fn func(d *SecretReferenceDie)) *SecretReferenceDie {
+func (d *SecretReferenceDie) DieWith(fns ...func(d *SecretReferenceDie)) *SecretReferenceDie {
 	nd := SecretReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1463,9 +1487,13 @@ func (d *TopologySelectorTermDie) DieStampAt(jp string, fn interface{}) *Topolog
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TopologySelectorTermDie) DieWith(fn func(d *TopologySelectorTermDie)) *TopologySelectorTermDie {
+func (d *TopologySelectorTermDie) DieWith(fns ...func(d *TopologySelectorTermDie)) *TopologySelectorTermDie {
 	nd := TopologySelectorTermBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1648,9 +1676,13 @@ func (d *TopologySelectorLabelRequirementDie) DieStampAt(jp string, fn interface
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TopologySelectorLabelRequirementDie) DieWith(fn func(d *TopologySelectorLabelRequirementDie)) *TopologySelectorLabelRequirementDie {
+func (d *TopologySelectorLabelRequirementDie) DieWith(fns ...func(d *TopologySelectorLabelRequirementDie)) *TopologySelectorLabelRequirementDie {
 	nd := TopologySelectorLabelRequirementBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1855,9 +1887,13 @@ func (d *ComponentStatusDie) DieStampAt(jp string, fn interface{}) *ComponentSta
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ComponentStatusDie) DieWith(fn func(d *ComponentStatusDie)) *ComponentStatusDie {
+func (d *ComponentStatusDie) DieWith(fns ...func(d *ComponentStatusDie)) *ComponentStatusDie {
 	nd := ComponentStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2107,9 +2143,13 @@ func (d *ConfigMapDie) DieStampAt(jp string, fn interface{}) *ConfigMapDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ConfigMapDie) DieWith(fn func(d *ConfigMapDie)) *ConfigMapDie {
+func (d *ConfigMapDie) DieWith(fns ...func(d *ConfigMapDie)) *ConfigMapDie {
 	nd := ConfigMapBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2344,9 +2384,13 @@ func (d *ContainerDie) DieStampAt(jp string, fn interface{}) *ContainerDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ContainerDie) DieWith(fn func(d *ContainerDie)) *ContainerDie {
+func (d *ContainerDie) DieWith(fns ...func(d *ContainerDie)) *ContainerDie {
 	nd := ContainerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2683,9 +2727,13 @@ func (d *ContainerPortDie) DieStampAt(jp string, fn interface{}) *ContainerPortD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ContainerPortDie) DieWith(fn func(d *ContainerPortDie)) *ContainerPortDie {
+func (d *ContainerPortDie) DieWith(fns ...func(d *ContainerPortDie)) *ContainerPortDie {
 	nd := ContainerPortBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2896,9 +2944,13 @@ func (d *EnvFromSourceDie) DieStampAt(jp string, fn interface{}) *EnvFromSourceD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EnvFromSourceDie) DieWith(fn func(d *EnvFromSourceDie)) *EnvFromSourceDie {
+func (d *EnvFromSourceDie) DieWith(fns ...func(d *EnvFromSourceDie)) *EnvFromSourceDie {
 	nd := EnvFromSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3095,9 +3147,13 @@ func (d *ConfigMapEnvSourceDie) DieStampAt(jp string, fn interface{}) *ConfigMap
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ConfigMapEnvSourceDie) DieWith(fn func(d *ConfigMapEnvSourceDie)) *ConfigMapEnvSourceDie {
+func (d *ConfigMapEnvSourceDie) DieWith(fns ...func(d *ConfigMapEnvSourceDie)) *ConfigMapEnvSourceDie {
 	nd := ConfigMapEnvSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3287,9 +3343,13 @@ func (d *SecretEnvSourceDie) DieStampAt(jp string, fn interface{}) *SecretEnvSou
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SecretEnvSourceDie) DieWith(fn func(d *SecretEnvSourceDie)) *SecretEnvSourceDie {
+func (d *SecretEnvSourceDie) DieWith(fns ...func(d *SecretEnvSourceDie)) *SecretEnvSourceDie {
 	nd := SecretEnvSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3479,9 +3539,13 @@ func (d *EnvVarDie) DieStampAt(jp string, fn interface{}) *EnvVarDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EnvVarDie) DieWith(fn func(d *EnvVarDie)) *EnvVarDie {
+func (d *EnvVarDie) DieWith(fns ...func(d *EnvVarDie)) *EnvVarDie {
 	nd := EnvVarBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3678,9 +3742,13 @@ func (d *EnvVarSourceDie) DieStampAt(jp string, fn interface{}) *EnvVarSourceDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EnvVarSourceDie) DieWith(fn func(d *EnvVarSourceDie)) *EnvVarSourceDie {
+func (d *EnvVarSourceDie) DieWith(fns ...func(d *EnvVarSourceDie)) *EnvVarSourceDie {
 	nd := EnvVarSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3884,9 +3952,13 @@ func (d *ObjectFieldSelectorDie) DieStampAt(jp string, fn interface{}) *ObjectFi
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ObjectFieldSelectorDie) DieWith(fn func(d *ObjectFieldSelectorDie)) *ObjectFieldSelectorDie {
+func (d *ObjectFieldSelectorDie) DieWith(fns ...func(d *ObjectFieldSelectorDie)) *ObjectFieldSelectorDie {
 	nd := ObjectFieldSelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4076,9 +4148,13 @@ func (d *ResourceFieldSelectorDie) DieStampAt(jp string, fn interface{}) *Resour
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ResourceFieldSelectorDie) DieWith(fn func(d *ResourceFieldSelectorDie)) *ResourceFieldSelectorDie {
+func (d *ResourceFieldSelectorDie) DieWith(fns ...func(d *ResourceFieldSelectorDie)) *ResourceFieldSelectorDie {
 	nd := ResourceFieldSelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4275,9 +4351,13 @@ func (d *ConfigMapKeySelectorDie) DieStampAt(jp string, fn interface{}) *ConfigM
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ConfigMapKeySelectorDie) DieWith(fn func(d *ConfigMapKeySelectorDie)) *ConfigMapKeySelectorDie {
+func (d *ConfigMapKeySelectorDie) DieWith(fns ...func(d *ConfigMapKeySelectorDie)) *ConfigMapKeySelectorDie {
 	nd := ConfigMapKeySelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4474,9 +4554,13 @@ func (d *SecretKeySelectorDie) DieStampAt(jp string, fn interface{}) *SecretKeyS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SecretKeySelectorDie) DieWith(fn func(d *SecretKeySelectorDie)) *SecretKeySelectorDie {
+func (d *SecretKeySelectorDie) DieWith(fns ...func(d *SecretKeySelectorDie)) *SecretKeySelectorDie {
 	nd := SecretKeySelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4673,9 +4757,13 @@ func (d *ResourceRequirementsDie) DieStampAt(jp string, fn interface{}) *Resourc
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ResourceRequirementsDie) DieWith(fn func(d *ResourceRequirementsDie)) *ResourceRequirementsDie {
+func (d *ResourceRequirementsDie) DieWith(fns ...func(d *ResourceRequirementsDie)) *ResourceRequirementsDie {
 	nd := ResourceRequirementsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4876,9 +4964,13 @@ func (d *ResourceClaimDie) DieStampAt(jp string, fn interface{}) *ResourceClaimD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ResourceClaimDie) DieWith(fn func(d *ResourceClaimDie)) *ResourceClaimDie {
+func (d *ResourceClaimDie) DieWith(fns ...func(d *ResourceClaimDie)) *ResourceClaimDie {
 	nd := ResourceClaimBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -5061,9 +5153,13 @@ func (d *ContainerResizePolicyDie) DieStampAt(jp string, fn interface{}) *Contai
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ContainerResizePolicyDie) DieWith(fn func(d *ContainerResizePolicyDie)) *ContainerResizePolicyDie {
+func (d *ContainerResizePolicyDie) DieWith(fns ...func(d *ContainerResizePolicyDie)) *ContainerResizePolicyDie {
 	nd := ContainerResizePolicyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -5253,9 +5349,13 @@ func (d *VolumeMountDie) DieStampAt(jp string, fn interface{}) *VolumeMountDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeMountDie) DieWith(fn func(d *VolumeMountDie)) *VolumeMountDie {
+func (d *VolumeMountDie) DieWith(fns ...func(d *VolumeMountDie)) *VolumeMountDie {
 	nd := VolumeMountBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -5473,9 +5573,13 @@ func (d *VolumeDeviceDie) DieStampAt(jp string, fn interface{}) *VolumeDeviceDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeDeviceDie) DieWith(fn func(d *VolumeDeviceDie)) *VolumeDeviceDie {
+func (d *VolumeDeviceDie) DieWith(fns ...func(d *VolumeDeviceDie)) *VolumeDeviceDie {
 	nd := VolumeDeviceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -5665,9 +5769,13 @@ func (d *ProbeDie) DieStampAt(jp string, fn interface{}) *ProbeDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ProbeDie) DieWith(fn func(d *ProbeDie)) *ProbeDie {
+func (d *ProbeDie) DieWith(fns ...func(d *ProbeDie)) *ProbeDie {
 	nd := ProbeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -5892,9 +6000,13 @@ func (d *LifecycleDie) DieStampAt(jp string, fn interface{}) *LifecycleDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LifecycleDie) DieWith(fn func(d *LifecycleDie)) *LifecycleDie {
+func (d *LifecycleDie) DieWith(fns ...func(d *LifecycleDie)) *LifecycleDie {
 	nd := LifecycleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -6084,9 +6196,13 @@ func (d *LifecycleHandlerDie) DieStampAt(jp string, fn interface{}) *LifecycleHa
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LifecycleHandlerDie) DieWith(fn func(d *LifecycleHandlerDie)) *LifecycleHandlerDie {
+func (d *LifecycleHandlerDie) DieWith(fns ...func(d *LifecycleHandlerDie)) *LifecycleHandlerDie {
 	nd := LifecycleHandlerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -6283,9 +6399,13 @@ func (d *ProbeHandlerDie) DieStampAt(jp string, fn interface{}) *ProbeHandlerDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ProbeHandlerDie) DieWith(fn func(d *ProbeHandlerDie)) *ProbeHandlerDie {
+func (d *ProbeHandlerDie) DieWith(fns ...func(d *ProbeHandlerDie)) *ProbeHandlerDie {
 	nd := ProbeHandlerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -6489,9 +6609,13 @@ func (d *ExecActionDie) DieStampAt(jp string, fn interface{}) *ExecActionDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ExecActionDie) DieWith(fn func(d *ExecActionDie)) *ExecActionDie {
+func (d *ExecActionDie) DieWith(fns ...func(d *ExecActionDie)) *ExecActionDie {
 	nd := ExecActionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -6674,9 +6798,13 @@ func (d *HTTPGetActionDie) DieStampAt(jp string, fn interface{}) *HTTPGetActionD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *HTTPGetActionDie) DieWith(fn func(d *HTTPGetActionDie)) *HTTPGetActionDie {
+func (d *HTTPGetActionDie) DieWith(fns ...func(d *HTTPGetActionDie)) *HTTPGetActionDie {
 	nd := HTTPGetActionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -6901,9 +7029,13 @@ func (d *HTTPHeaderDie) DieStampAt(jp string, fn interface{}) *HTTPHeaderDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *HTTPHeaderDie) DieWith(fn func(d *HTTPHeaderDie)) *HTTPHeaderDie {
+func (d *HTTPHeaderDie) DieWith(fns ...func(d *HTTPHeaderDie)) *HTTPHeaderDie {
 	nd := HTTPHeaderBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -7093,9 +7225,13 @@ func (d *TCPSocketActionDie) DieStampAt(jp string, fn interface{}) *TCPSocketAct
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TCPSocketActionDie) DieWith(fn func(d *TCPSocketActionDie)) *TCPSocketActionDie {
+func (d *TCPSocketActionDie) DieWith(fns ...func(d *TCPSocketActionDie)) *TCPSocketActionDie {
 	nd := TCPSocketActionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -7299,9 +7435,13 @@ func (d *GRPCActionDie) DieStampAt(jp string, fn interface{}) *GRPCActionDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GRPCActionDie) DieWith(fn func(d *GRPCActionDie)) *GRPCActionDie {
+func (d *GRPCActionDie) DieWith(fns ...func(d *GRPCActionDie)) *GRPCActionDie {
 	nd := GRPCActionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -7493,9 +7633,13 @@ func (d *SecurityContextDie) DieStampAt(jp string, fn interface{}) *SecurityCont
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SecurityContextDie) DieWith(fn func(d *SecurityContextDie)) *SecurityContextDie {
+func (d *SecurityContextDie) DieWith(fns ...func(d *SecurityContextDie)) *SecurityContextDie {
 	nd := SecurityContextBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -7748,9 +7892,13 @@ func (d *CapabilitiesDie) DieStampAt(jp string, fn interface{}) *CapabilitiesDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CapabilitiesDie) DieWith(fn func(d *CapabilitiesDie)) *CapabilitiesDie {
+func (d *CapabilitiesDie) DieWith(fns ...func(d *CapabilitiesDie)) *CapabilitiesDie {
 	nd := CapabilitiesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -7940,9 +8088,13 @@ func (d *SELinuxOptionsDie) DieStampAt(jp string, fn interface{}) *SELinuxOption
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SELinuxOptionsDie) DieWith(fn func(d *SELinuxOptionsDie)) *SELinuxOptionsDie {
+func (d *SELinuxOptionsDie) DieWith(fns ...func(d *SELinuxOptionsDie)) *SELinuxOptionsDie {
 	nd := SELinuxOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -8146,9 +8298,13 @@ func (d *WindowsSecurityContextOptionsDie) DieStampAt(jp string, fn interface{})
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *WindowsSecurityContextOptionsDie) DieWith(fn func(d *WindowsSecurityContextOptionsDie)) *WindowsSecurityContextOptionsDie {
+func (d *WindowsSecurityContextOptionsDie) DieWith(fns ...func(d *WindowsSecurityContextOptionsDie)) *WindowsSecurityContextOptionsDie {
 	nd := WindowsSecurityContextOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -8352,9 +8508,13 @@ func (d *SeccompProfileDie) DieStampAt(jp string, fn interface{}) *SeccompProfil
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SeccompProfileDie) DieWith(fn func(d *SeccompProfileDie)) *SeccompProfileDie {
+func (d *SeccompProfileDie) DieWith(fns ...func(d *SeccompProfileDie)) *SeccompProfileDie {
 	nd := SeccompProfileBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -8546,9 +8706,13 @@ func (d *ContainerStatusDie) DieStampAt(jp string, fn interface{}) *ContainerSta
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ContainerStatusDie) DieWith(fn func(d *ContainerStatusDie)) *ContainerStatusDie {
+func (d *ContainerStatusDie) DieWith(fns ...func(d *ContainerStatusDie)) *ContainerStatusDie {
 	nd := ContainerStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -8803,9 +8967,13 @@ func (d *ContainerStateDie) DieStampAt(jp string, fn interface{}) *ContainerStat
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ContainerStateDie) DieWith(fn func(d *ContainerStateDie)) *ContainerStateDie {
+func (d *ContainerStateDie) DieWith(fns ...func(d *ContainerStateDie)) *ContainerStateDie {
 	nd := ContainerStateBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -9002,9 +9170,13 @@ func (d *ContainerStateWaitingDie) DieStampAt(jp string, fn interface{}) *Contai
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ContainerStateWaitingDie) DieWith(fn func(d *ContainerStateWaitingDie)) *ContainerStateWaitingDie {
+func (d *ContainerStateWaitingDie) DieWith(fns ...func(d *ContainerStateWaitingDie)) *ContainerStateWaitingDie {
 	nd := ContainerStateWaitingBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -9194,9 +9366,13 @@ func (d *ContainerStateRunningDie) DieStampAt(jp string, fn interface{}) *Contai
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ContainerStateRunningDie) DieWith(fn func(d *ContainerStateRunningDie)) *ContainerStateRunningDie {
+func (d *ContainerStateRunningDie) DieWith(fns ...func(d *ContainerStateRunningDie)) *ContainerStateRunningDie {
 	nd := ContainerStateRunningBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -9379,9 +9555,13 @@ func (d *ContainerStateTerminatedDie) DieStampAt(jp string, fn interface{}) *Con
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ContainerStateTerminatedDie) DieWith(fn func(d *ContainerStateTerminatedDie)) *ContainerStateTerminatedDie {
+func (d *ContainerStateTerminatedDie) DieWith(fns ...func(d *ContainerStateTerminatedDie)) *ContainerStateTerminatedDie {
 	nd := ContainerStateTerminatedBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -9621,9 +9801,13 @@ func (d *EndpointsDie) DieStampAt(jp string, fn interface{}) *EndpointsDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EndpointsDie) DieWith(fn func(d *EndpointsDie)) *EndpointsDie {
+func (d *EndpointsDie) DieWith(fns ...func(d *EndpointsDie)) *EndpointsDie {
 	nd := EndpointsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -9858,9 +10042,13 @@ func (d *EndpointSubsetDie) DieStampAt(jp string, fn interface{}) *EndpointSubse
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EndpointSubsetDie) DieWith(fn func(d *EndpointSubsetDie)) *EndpointSubsetDie {
+func (d *EndpointSubsetDie) DieWith(fns ...func(d *EndpointSubsetDie)) *EndpointSubsetDie {
 	nd := EndpointSubsetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -10057,9 +10245,13 @@ func (d *EndpointAddressDie) DieStampAt(jp string, fn interface{}) *EndpointAddr
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EndpointAddressDie) DieWith(fn func(d *EndpointAddressDie)) *EndpointAddressDie {
+func (d *EndpointAddressDie) DieWith(fns ...func(d *EndpointAddressDie)) *EndpointAddressDie {
 	nd := EndpointAddressBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -10263,9 +10455,13 @@ func (d *EndpointPortDie) DieStampAt(jp string, fn interface{}) *EndpointPortDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EndpointPortDie) DieWith(fn func(d *EndpointPortDie)) *EndpointPortDie {
+func (d *EndpointPortDie) DieWith(fns ...func(d *EndpointPortDie)) *EndpointPortDie {
 	nd := EndpointPortBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -10490,9 +10686,13 @@ func (d *EventDie) DieStampAt(jp string, fn interface{}) *EventDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EventDie) DieWith(fn func(d *EventDie)) *EventDie {
+func (d *EventDie) DieWith(fns ...func(d *EventDie)) *EventDie {
 	nd := EventBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -10818,9 +11018,13 @@ func (d *EventSourceDie) DieStampAt(jp string, fn interface{}) *EventSourceDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EventSourceDie) DieWith(fn func(d *EventSourceDie)) *EventSourceDie {
+func (d *EventSourceDie) DieWith(fns ...func(d *EventSourceDie)) *EventSourceDie {
 	nd := EventSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -11010,9 +11214,13 @@ func (d *EventSeriesDie) DieStampAt(jp string, fn interface{}) *EventSeriesDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EventSeriesDie) DieWith(fn func(d *EventSeriesDie)) *EventSeriesDie {
+func (d *EventSeriesDie) DieWith(fns ...func(d *EventSeriesDie)) *EventSeriesDie {
 	nd := EventSeriesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -11217,9 +11425,13 @@ func (d *LimitRangeDie) DieStampAt(jp string, fn interface{}) *LimitRangeDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LimitRangeDie) DieWith(fn func(d *LimitRangeDie)) *LimitRangeDie {
+func (d *LimitRangeDie) DieWith(fns ...func(d *LimitRangeDie)) *LimitRangeDie {
 	nd := LimitRangeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -11463,9 +11675,13 @@ func (d *LimitRangeSpecDie) DieStampAt(jp string, fn interface{}) *LimitRangeSpe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LimitRangeSpecDie) DieWith(fn func(d *LimitRangeSpecDie)) *LimitRangeSpecDie {
+func (d *LimitRangeSpecDie) DieWith(fns ...func(d *LimitRangeSpecDie)) *LimitRangeSpecDie {
 	nd := LimitRangeSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -11648,9 +11864,13 @@ func (d *LimitRangeItemDie) DieStampAt(jp string, fn interface{}) *LimitRangeIte
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LimitRangeItemDie) DieWith(fn func(d *LimitRangeItemDie)) *LimitRangeItemDie {
+func (d *LimitRangeItemDie) DieWith(fns ...func(d *LimitRangeItemDie)) *LimitRangeItemDie {
 	nd := LimitRangeItemBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -11883,9 +12103,13 @@ func (d *NamespaceDie) DieStampAt(jp string, fn interface{}) *NamespaceDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NamespaceDie) DieWith(fn func(d *NamespaceDie)) *NamespaceDie {
+func (d *NamespaceDie) DieWith(fns ...func(d *NamespaceDie)) *NamespaceDie {
 	nd := NamespaceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -12145,9 +12369,13 @@ func (d *NamespaceSpecDie) DieStampAt(jp string, fn interface{}) *NamespaceSpecD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NamespaceSpecDie) DieWith(fn func(d *NamespaceSpecDie)) *NamespaceSpecDie {
+func (d *NamespaceSpecDie) DieWith(fns ...func(d *NamespaceSpecDie)) *NamespaceSpecDie {
 	nd := NamespaceSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -12330,9 +12558,13 @@ func (d *NamespaceStatusDie) DieStampAt(jp string, fn interface{}) *NamespaceSta
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NamespaceStatusDie) DieWith(fn func(d *NamespaceStatusDie)) *NamespaceStatusDie {
+func (d *NamespaceStatusDie) DieWith(fns ...func(d *NamespaceStatusDie)) *NamespaceStatusDie {
 	nd := NamespaceStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -12537,9 +12769,13 @@ func (d *NodeDie) DieStampAt(jp string, fn interface{}) *NodeDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeDie) DieWith(fn func(d *NodeDie)) *NodeDie {
+func (d *NodeDie) DieWith(fns ...func(d *NodeDie)) *NodeDie {
 	nd := NodeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -12799,9 +13035,13 @@ func (d *NodeSpecDie) DieStampAt(jp string, fn interface{}) *NodeSpecDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeSpecDie) DieWith(fn func(d *NodeSpecDie)) *NodeSpecDie {
+func (d *NodeSpecDie) DieWith(fns ...func(d *NodeSpecDie)) *NodeSpecDie {
 	nd := NodeSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -13026,9 +13266,13 @@ func (d *TaintDie) DieStampAt(jp string, fn interface{}) *TaintDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TaintDie) DieWith(fn func(d *TaintDie)) *TaintDie {
+func (d *TaintDie) DieWith(fns ...func(d *TaintDie)) *TaintDie {
 	nd := TaintBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -13232,9 +13476,13 @@ func (d *NodeConfigSourceDie) DieStampAt(jp string, fn interface{}) *NodeConfigS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeConfigSourceDie) DieWith(fn func(d *NodeConfigSourceDie)) *NodeConfigSourceDie {
+func (d *NodeConfigSourceDie) DieWith(fns ...func(d *NodeConfigSourceDie)) *NodeConfigSourceDie {
 	nd := NodeConfigSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -13417,9 +13665,13 @@ func (d *ConfigMapNodeConfigSourceDie) DieStampAt(jp string, fn interface{}) *Co
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ConfigMapNodeConfigSourceDie) DieWith(fn func(d *ConfigMapNodeConfigSourceDie)) *ConfigMapNodeConfigSourceDie {
+func (d *ConfigMapNodeConfigSourceDie) DieWith(fns ...func(d *ConfigMapNodeConfigSourceDie)) *ConfigMapNodeConfigSourceDie {
 	nd := ConfigMapNodeConfigSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -13630,9 +13882,13 @@ func (d *NodeStatusDie) DieStampAt(jp string, fn interface{}) *NodeStatusDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeStatusDie) DieWith(fn func(d *NodeStatusDie)) *NodeStatusDie {
+func (d *NodeStatusDie) DieWith(fns ...func(d *NodeStatusDie)) *NodeStatusDie {
 	nd := NodeStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -13885,9 +14141,13 @@ func (d *NodeAddressDie) DieStampAt(jp string, fn interface{}) *NodeAddressDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeAddressDie) DieWith(fn func(d *NodeAddressDie)) *NodeAddressDie {
+func (d *NodeAddressDie) DieWith(fns ...func(d *NodeAddressDie)) *NodeAddressDie {
 	nd := NodeAddressBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -14077,9 +14337,13 @@ func (d *NodeDaemonEndpointsDie) DieStampAt(jp string, fn interface{}) *NodeDaem
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeDaemonEndpointsDie) DieWith(fn func(d *NodeDaemonEndpointsDie)) *NodeDaemonEndpointsDie {
+func (d *NodeDaemonEndpointsDie) DieWith(fns ...func(d *NodeDaemonEndpointsDie)) *NodeDaemonEndpointsDie {
 	nd := NodeDaemonEndpointsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -14262,9 +14526,13 @@ func (d *DaemonEndpointDie) DieStampAt(jp string, fn interface{}) *DaemonEndpoin
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DaemonEndpointDie) DieWith(fn func(d *DaemonEndpointDie)) *DaemonEndpointDie {
+func (d *DaemonEndpointDie) DieWith(fns ...func(d *DaemonEndpointDie)) *DaemonEndpointDie {
 	nd := DaemonEndpointBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -14447,9 +14715,13 @@ func (d *NodeSystemInfoDie) DieStampAt(jp string, fn interface{}) *NodeSystemInf
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeSystemInfoDie) DieWith(fn func(d *NodeSystemInfoDie)) *NodeSystemInfoDie {
+func (d *NodeSystemInfoDie) DieWith(fns ...func(d *NodeSystemInfoDie)) *NodeSystemInfoDie {
 	nd := NodeSystemInfoBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -14695,9 +14967,13 @@ func (d *ContainerImageDie) DieStampAt(jp string, fn interface{}) *ContainerImag
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ContainerImageDie) DieWith(fn func(d *ContainerImageDie)) *ContainerImageDie {
+func (d *ContainerImageDie) DieWith(fns ...func(d *ContainerImageDie)) *ContainerImageDie {
 	nd := ContainerImageBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -14887,9 +15163,13 @@ func (d *AttachedVolumeDie) DieStampAt(jp string, fn interface{}) *AttachedVolum
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AttachedVolumeDie) DieWith(fn func(d *AttachedVolumeDie)) *AttachedVolumeDie {
+func (d *AttachedVolumeDie) DieWith(fns ...func(d *AttachedVolumeDie)) *AttachedVolumeDie {
 	nd := AttachedVolumeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -15079,9 +15359,13 @@ func (d *NodeConfigStatusDie) DieStampAt(jp string, fn interface{}) *NodeConfigS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeConfigStatusDie) DieWith(fn func(d *NodeConfigStatusDie)) *NodeConfigStatusDie {
+func (d *NodeConfigStatusDie) DieWith(fns ...func(d *NodeConfigStatusDie)) *NodeConfigStatusDie {
 	nd := NodeConfigStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -15300,9 +15584,13 @@ func (d *PersistentVolumeDie) DieStampAt(jp string, fn interface{}) *PersistentV
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PersistentVolumeDie) DieWith(fn func(d *PersistentVolumeDie)) *PersistentVolumeDie {
+func (d *PersistentVolumeDie) DieWith(fns ...func(d *PersistentVolumeDie)) *PersistentVolumeDie {
 	nd := PersistentVolumeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -15562,9 +15850,13 @@ func (d *PersistentVolumeSpecDie) DieStampAt(jp string, fn interface{}) *Persist
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PersistentVolumeSpecDie) DieWith(fn func(d *PersistentVolumeSpecDie)) *PersistentVolumeSpecDie {
+func (d *PersistentVolumeSpecDie) DieWith(fns ...func(d *PersistentVolumeSpecDie)) *PersistentVolumeSpecDie {
 	nd := PersistentVolumeSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -15803,9 +16095,13 @@ func (d *PersistentVolumeStatusDie) DieStampAt(jp string, fn interface{}) *Persi
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PersistentVolumeStatusDie) DieWith(fn func(d *PersistentVolumeStatusDie)) *PersistentVolumeStatusDie {
+func (d *PersistentVolumeStatusDie) DieWith(fns ...func(d *PersistentVolumeStatusDie)) *PersistentVolumeStatusDie {
 	nd := PersistentVolumeStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -16002,9 +16298,13 @@ func (d *GlusterfsPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GlusterfsPersistentVolumeSourceDie) DieWith(fn func(d *GlusterfsPersistentVolumeSourceDie)) *GlusterfsPersistentVolumeSourceDie {
+func (d *GlusterfsPersistentVolumeSourceDie) DieWith(fns ...func(d *GlusterfsPersistentVolumeSourceDie)) *GlusterfsPersistentVolumeSourceDie {
 	nd := GlusterfsPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -16208,9 +16508,13 @@ func (d *RBDPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) *RB
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RBDPersistentVolumeSourceDie) DieWith(fn func(d *RBDPersistentVolumeSourceDie)) *RBDPersistentVolumeSourceDie {
+func (d *RBDPersistentVolumeSourceDie) DieWith(fns ...func(d *RBDPersistentVolumeSourceDie)) *RBDPersistentVolumeSourceDie {
 	nd := RBDPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -16442,9 +16746,13 @@ func (d *ISCSIPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) *
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ISCSIPersistentVolumeSourceDie) DieWith(fn func(d *ISCSIPersistentVolumeSourceDie)) *ISCSIPersistentVolumeSourceDie {
+func (d *ISCSIPersistentVolumeSourceDie) DieWith(fns ...func(d *ISCSIPersistentVolumeSourceDie)) *ISCSIPersistentVolumeSourceDie {
 	nd := ISCSIPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -16697,9 +17005,13 @@ func (d *CinderPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) 
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CinderPersistentVolumeSourceDie) DieWith(fn func(d *CinderPersistentVolumeSourceDie)) *CinderPersistentVolumeSourceDie {
+func (d *CinderPersistentVolumeSourceDie) DieWith(fns ...func(d *CinderPersistentVolumeSourceDie)) *CinderPersistentVolumeSourceDie {
 	nd := CinderPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -16903,9 +17215,13 @@ func (d *CephFSPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) 
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CephFSPersistentVolumeSourceDie) DieWith(fn func(d *CephFSPersistentVolumeSourceDie)) *CephFSPersistentVolumeSourceDie {
+func (d *CephFSPersistentVolumeSourceDie) DieWith(fns ...func(d *CephFSPersistentVolumeSourceDie)) *CephFSPersistentVolumeSourceDie {
 	nd := CephFSPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -17123,9 +17439,13 @@ func (d *FlexPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) *F
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *FlexPersistentVolumeSourceDie) DieWith(fn func(d *FlexPersistentVolumeSourceDie)) *FlexPersistentVolumeSourceDie {
+func (d *FlexPersistentVolumeSourceDie) DieWith(fns ...func(d *FlexPersistentVolumeSourceDie)) *FlexPersistentVolumeSourceDie {
 	nd := FlexPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -17336,9 +17656,13 @@ func (d *AzureFilePersistentVolumeSourceDie) DieStampAt(jp string, fn interface{
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AzureFilePersistentVolumeSourceDie) DieWith(fn func(d *AzureFilePersistentVolumeSourceDie)) *AzureFilePersistentVolumeSourceDie {
+func (d *AzureFilePersistentVolumeSourceDie) DieWith(fns ...func(d *AzureFilePersistentVolumeSourceDie)) *AzureFilePersistentVolumeSourceDie {
 	nd := AzureFilePersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -17542,9 +17866,13 @@ func (d *ScaleIOPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{})
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ScaleIOPersistentVolumeSourceDie) DieWith(fn func(d *ScaleIOPersistentVolumeSourceDie)) *ScaleIOPersistentVolumeSourceDie {
+func (d *ScaleIOPersistentVolumeSourceDie) DieWith(fns ...func(d *ScaleIOPersistentVolumeSourceDie)) *ScaleIOPersistentVolumeSourceDie {
 	nd := ScaleIOPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -17790,9 +18118,13 @@ func (d *LocalVolumeSourceDie) DieStampAt(jp string, fn interface{}) *LocalVolum
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LocalVolumeSourceDie) DieWith(fn func(d *LocalVolumeSourceDie)) *LocalVolumeSourceDie {
+func (d *LocalVolumeSourceDie) DieWith(fns ...func(d *LocalVolumeSourceDie)) *LocalVolumeSourceDie {
 	nd := LocalVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -17982,9 +18314,13 @@ func (d *StorageOSPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StorageOSPersistentVolumeSourceDie) DieWith(fn func(d *StorageOSPersistentVolumeSourceDie)) *StorageOSPersistentVolumeSourceDie {
+func (d *StorageOSPersistentVolumeSourceDie) DieWith(fns ...func(d *StorageOSPersistentVolumeSourceDie)) *StorageOSPersistentVolumeSourceDie {
 	nd := StorageOSPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -18195,9 +18531,13 @@ func (d *CSIPersistentVolumeSourceDie) DieStampAt(jp string, fn interface{}) *CS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CSIPersistentVolumeSourceDie) DieWith(fn func(d *CSIPersistentVolumeSourceDie)) *CSIPersistentVolumeSourceDie {
+func (d *CSIPersistentVolumeSourceDie) DieWith(fns ...func(d *CSIPersistentVolumeSourceDie)) *CSIPersistentVolumeSourceDie {
 	nd := CSIPersistentVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -18443,9 +18783,13 @@ func (d *VolumeNodeAffinityDie) DieStampAt(jp string, fn interface{}) *VolumeNod
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeNodeAffinityDie) DieWith(fn func(d *VolumeNodeAffinityDie)) *VolumeNodeAffinityDie {
+func (d *VolumeNodeAffinityDie) DieWith(fns ...func(d *VolumeNodeAffinityDie)) *VolumeNodeAffinityDie {
 	nd := VolumeNodeAffinityBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -18628,9 +18972,13 @@ func (d *NodeSelectorDie) DieStampAt(jp string, fn interface{}) *NodeSelectorDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeSelectorDie) DieWith(fn func(d *NodeSelectorDie)) *NodeSelectorDie {
+func (d *NodeSelectorDie) DieWith(fns ...func(d *NodeSelectorDie)) *NodeSelectorDie {
 	nd := NodeSelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -18813,9 +19161,13 @@ func (d *NodeSelectorTermDie) DieStampAt(jp string, fn interface{}) *NodeSelecto
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeSelectorTermDie) DieWith(fn func(d *NodeSelectorTermDie)) *NodeSelectorTermDie {
+func (d *NodeSelectorTermDie) DieWith(fns ...func(d *NodeSelectorTermDie)) *NodeSelectorTermDie {
 	nd := NodeSelectorTermBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -19005,9 +19357,13 @@ func (d *NodeSelectorRequirementDie) DieStampAt(jp string, fn interface{}) *Node
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NodeSelectorRequirementDie) DieWith(fn func(d *NodeSelectorRequirementDie)) *NodeSelectorRequirementDie {
+func (d *NodeSelectorRequirementDie) DieWith(fns ...func(d *NodeSelectorRequirementDie)) *NodeSelectorRequirementDie {
 	nd := NodeSelectorRequirementBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -19219,9 +19575,13 @@ func (d *PersistentVolumeClaimDie) DieStampAt(jp string, fn interface{}) *Persis
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PersistentVolumeClaimDie) DieWith(fn func(d *PersistentVolumeClaimDie)) *PersistentVolumeClaimDie {
+func (d *PersistentVolumeClaimDie) DieWith(fns ...func(d *PersistentVolumeClaimDie)) *PersistentVolumeClaimDie {
 	nd := PersistentVolumeClaimBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -19481,9 +19841,13 @@ func (d *PersistentVolumeClaimSpecDie) DieStampAt(jp string, fn interface{}) *Pe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PersistentVolumeClaimSpecDie) DieWith(fn func(d *PersistentVolumeClaimSpecDie)) *PersistentVolumeClaimSpecDie {
+func (d *PersistentVolumeClaimSpecDie) DieWith(fns ...func(d *PersistentVolumeClaimSpecDie)) *PersistentVolumeClaimSpecDie {
 	nd := PersistentVolumeClaimSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -19715,9 +20079,13 @@ func (d *PersistentVolumeClaimStatusDie) DieStampAt(jp string, fn interface{}) *
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PersistentVolumeClaimStatusDie) DieWith(fn func(d *PersistentVolumeClaimStatusDie)) *PersistentVolumeClaimStatusDie {
+func (d *PersistentVolumeClaimStatusDie) DieWith(fns ...func(d *PersistentVolumeClaimStatusDie)) *PersistentVolumeClaimStatusDie {
 	nd := PersistentVolumeClaimStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -19935,9 +20303,13 @@ func (d *PersistentVolumeClaimTemplateDie) DieStampAt(jp string, fn interface{})
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PersistentVolumeClaimTemplateDie) DieWith(fn func(d *PersistentVolumeClaimTemplateDie)) *PersistentVolumeClaimTemplateDie {
+func (d *PersistentVolumeClaimTemplateDie) DieWith(fns ...func(d *PersistentVolumeClaimTemplateDie)) *PersistentVolumeClaimTemplateDie {
 	nd := PersistentVolumeClaimTemplateBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -20142,9 +20514,13 @@ func (d *PodDie) DieStampAt(jp string, fn interface{}) *PodDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodDie) DieWith(fn func(d *PodDie)) *PodDie {
+func (d *PodDie) DieWith(fns ...func(d *PodDie)) *PodDie {
 	nd := PodBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -20404,9 +20780,13 @@ func (d *PodSpecDie) DieStampAt(jp string, fn interface{}) *PodSpecDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodSpecDie) DieWith(fn func(d *PodSpecDie)) *PodSpecDie {
+func (d *PodSpecDie) DieWith(fns ...func(d *PodSpecDie)) *PodSpecDie {
 	nd := PodSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -20867,9 +21247,13 @@ func (d *PodSchedulingGateDie) DieStampAt(jp string, fn interface{}) *PodSchedul
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodSchedulingGateDie) DieWith(fn func(d *PodSchedulingGateDie)) *PodSchedulingGateDie {
+func (d *PodSchedulingGateDie) DieWith(fns ...func(d *PodSchedulingGateDie)) *PodSchedulingGateDie {
 	nd := PodSchedulingGateBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -21052,9 +21436,13 @@ func (d *PodResourceClaimDie) DieStampAt(jp string, fn interface{}) *PodResource
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodResourceClaimDie) DieWith(fn func(d *PodResourceClaimDie)) *PodResourceClaimDie {
+func (d *PodResourceClaimDie) DieWith(fns ...func(d *PodResourceClaimDie)) *PodResourceClaimDie {
 	nd := PodResourceClaimBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -21244,9 +21632,13 @@ func (d *ClaimSourceDie) DieStampAt(jp string, fn interface{}) *ClaimSourceDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ClaimSourceDie) DieWith(fn func(d *ClaimSourceDie)) *ClaimSourceDie {
+func (d *ClaimSourceDie) DieWith(fns ...func(d *ClaimSourceDie)) *ClaimSourceDie {
 	nd := ClaimSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -21442,9 +21834,13 @@ func (d *PodSecurityContextDie) DieStampAt(jp string, fn interface{}) *PodSecuri
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodSecurityContextDie) DieWith(fn func(d *PodSecurityContextDie)) *PodSecurityContextDie {
+func (d *PodSecurityContextDie) DieWith(fns ...func(d *PodSecurityContextDie)) *PodSecurityContextDie {
 	nd := PodSecurityContextBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -21694,9 +22090,13 @@ func (d *SysctlDie) DieStampAt(jp string, fn interface{}) *SysctlDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SysctlDie) DieWith(fn func(d *SysctlDie)) *SysctlDie {
+func (d *SysctlDie) DieWith(fns ...func(d *SysctlDie)) *SysctlDie {
 	nd := SysctlBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -21886,9 +22286,13 @@ func (d *TolerationDie) DieStampAt(jp string, fn interface{}) *TolerationDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TolerationDie) DieWith(fn func(d *TolerationDie)) *TolerationDie {
+func (d *TolerationDie) DieWith(fns ...func(d *TolerationDie)) *TolerationDie {
 	nd := TolerationBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -22099,9 +22503,13 @@ func (d *HostAliasDie) DieStampAt(jp string, fn interface{}) *HostAliasDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *HostAliasDie) DieWith(fn func(d *HostAliasDie)) *HostAliasDie {
+func (d *HostAliasDie) DieWith(fns ...func(d *HostAliasDie)) *HostAliasDie {
 	nd := HostAliasBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -22291,9 +22699,13 @@ func (d *PodDNSConfigDie) DieStampAt(jp string, fn interface{}) *PodDNSConfigDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodDNSConfigDie) DieWith(fn func(d *PodDNSConfigDie)) *PodDNSConfigDie {
+func (d *PodDNSConfigDie) DieWith(fns ...func(d *PodDNSConfigDie)) *PodDNSConfigDie {
 	nd := PodDNSConfigBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -22490,9 +22902,13 @@ func (d *PodDNSConfigOptionDie) DieStampAt(jp string, fn interface{}) *PodDNSCon
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodDNSConfigOptionDie) DieWith(fn func(d *PodDNSConfigOptionDie)) *PodDNSConfigOptionDie {
+func (d *PodDNSConfigOptionDie) DieWith(fns ...func(d *PodDNSConfigOptionDie)) *PodDNSConfigOptionDie {
 	nd := PodDNSConfigOptionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -22681,9 +23097,13 @@ func (d *PodReadinessGateDie) DieStampAt(jp string, fn interface{}) *PodReadines
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodReadinessGateDie) DieWith(fn func(d *PodReadinessGateDie)) *PodReadinessGateDie {
+func (d *PodReadinessGateDie) DieWith(fns ...func(d *PodReadinessGateDie)) *PodReadinessGateDie {
 	nd := PodReadinessGateBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -22866,9 +23286,13 @@ func (d *TopologySpreadConstraintDie) DieStampAt(jp string, fn interface{}) *Top
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TopologySpreadConstraintDie) DieWith(fn func(d *TopologySpreadConstraintDie)) *TopologySpreadConstraintDie {
+func (d *TopologySpreadConstraintDie) DieWith(fns ...func(d *TopologySpreadConstraintDie)) *TopologySpreadConstraintDie {
 	nd := TopologySpreadConstraintBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -23110,9 +23534,13 @@ func (d *PodOSDie) DieStampAt(jp string, fn interface{}) *PodOSDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodOSDie) DieWith(fn func(d *PodOSDie)) *PodOSDie {
+func (d *PodOSDie) DieWith(fns ...func(d *PodOSDie)) *PodOSDie {
 	nd := PodOSBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -23295,9 +23723,13 @@ func (d *PodStatusDie) DieStampAt(jp string, fn interface{}) *PodStatusDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodStatusDie) DieWith(fn func(d *PodStatusDie)) *PodStatusDie {
+func (d *PodStatusDie) DieWith(fns ...func(d *PodStatusDie)) *PodStatusDie {
 	nd := PodStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -23590,9 +24022,13 @@ func (d *PodTemplateDie) DieStampAt(jp string, fn interface{}) *PodTemplateDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodTemplateDie) DieWith(fn func(d *PodTemplateDie)) *PodTemplateDie {
+func (d *PodTemplateDie) DieWith(fns ...func(d *PodTemplateDie)) *PodTemplateDie {
 	nd := PodTemplateBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -23827,9 +24263,13 @@ func (d *PodTemplateSpecDie) DieStampAt(jp string, fn interface{}) *PodTemplateS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodTemplateSpecDie) DieWith(fn func(d *PodTemplateSpecDie)) *PodTemplateSpecDie {
+func (d *PodTemplateSpecDie) DieWith(fns ...func(d *PodTemplateSpecDie)) *PodTemplateSpecDie {
 	nd := PodTemplateSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -24034,9 +24474,13 @@ func (d *ReplicationControllerDie) DieStampAt(jp string, fn interface{}) *Replic
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ReplicationControllerDie) DieWith(fn func(d *ReplicationControllerDie)) *ReplicationControllerDie {
+func (d *ReplicationControllerDie) DieWith(fns ...func(d *ReplicationControllerDie)) *ReplicationControllerDie {
 	nd := ReplicationControllerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -24296,9 +24740,13 @@ func (d *ReplicationControllerSpecDie) DieStampAt(jp string, fn interface{}) *Re
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ReplicationControllerSpecDie) DieWith(fn func(d *ReplicationControllerSpecDie)) *ReplicationControllerSpecDie {
+func (d *ReplicationControllerSpecDie) DieWith(fns ...func(d *ReplicationControllerSpecDie)) *ReplicationControllerSpecDie {
 	nd := ReplicationControllerSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -24502,9 +24950,13 @@ func (d *ReplicationControllerStatusDie) DieStampAt(jp string, fn interface{}) *
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ReplicationControllerStatusDie) DieWith(fn func(d *ReplicationControllerStatusDie)) *ReplicationControllerStatusDie {
+func (d *ReplicationControllerStatusDie) DieWith(fns ...func(d *ReplicationControllerStatusDie)) *ReplicationControllerStatusDie {
 	nd := ReplicationControllerStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -24737,9 +25189,13 @@ func (d *ResourceQuotaDie) DieStampAt(jp string, fn interface{}) *ResourceQuotaD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ResourceQuotaDie) DieWith(fn func(d *ResourceQuotaDie)) *ResourceQuotaDie {
+func (d *ResourceQuotaDie) DieWith(fns ...func(d *ResourceQuotaDie)) *ResourceQuotaDie {
 	nd := ResourceQuotaBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -24999,9 +25455,13 @@ func (d *ResourceQuotaSpecDie) DieStampAt(jp string, fn interface{}) *ResourceQu
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ResourceQuotaSpecDie) DieWith(fn func(d *ResourceQuotaSpecDie)) *ResourceQuotaSpecDie {
+func (d *ResourceQuotaSpecDie) DieWith(fns ...func(d *ResourceQuotaSpecDie)) *ResourceQuotaSpecDie {
 	nd := ResourceQuotaSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -25198,9 +25658,13 @@ func (d *ScopeSelectorDie) DieStampAt(jp string, fn interface{}) *ScopeSelectorD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ScopeSelectorDie) DieWith(fn func(d *ScopeSelectorDie)) *ScopeSelectorDie {
+func (d *ScopeSelectorDie) DieWith(fns ...func(d *ScopeSelectorDie)) *ScopeSelectorDie {
 	nd := ScopeSelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -25383,9 +25847,13 @@ func (d *ScopedResourceSelectorRequirementDie) DieStampAt(jp string, fn interfac
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ScopedResourceSelectorRequirementDie) DieWith(fn func(d *ScopedResourceSelectorRequirementDie)) *ScopedResourceSelectorRequirementDie {
+func (d *ScopedResourceSelectorRequirementDie) DieWith(fns ...func(d *ScopedResourceSelectorRequirementDie)) *ScopedResourceSelectorRequirementDie {
 	nd := ScopedResourceSelectorRequirementBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -25582,9 +26050,13 @@ func (d *ResourceQuotaStatusDie) DieStampAt(jp string, fn interface{}) *Resource
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ResourceQuotaStatusDie) DieWith(fn func(d *ResourceQuotaStatusDie)) *ResourceQuotaStatusDie {
+func (d *ResourceQuotaStatusDie) DieWith(fns ...func(d *ResourceQuotaStatusDie)) *ResourceQuotaStatusDie {
 	nd := ResourceQuotaStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -25789,9 +26261,13 @@ func (d *SecretDie) DieStampAt(jp string, fn interface{}) *SecretDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SecretDie) DieWith(fn func(d *SecretDie)) *SecretDie {
+func (d *SecretDie) DieWith(fns ...func(d *SecretDie)) *SecretDie {
 	nd := SecretBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -26048,9 +26524,13 @@ func (d *ServiceDie) DieStampAt(jp string, fn interface{}) *ServiceDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServiceDie) DieWith(fn func(d *ServiceDie)) *ServiceDie {
+func (d *ServiceDie) DieWith(fns ...func(d *ServiceDie)) *ServiceDie {
 	nd := ServiceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -26310,9 +26790,13 @@ func (d *ServiceSpecDie) DieStampAt(jp string, fn interface{}) *ServiceSpecDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServiceSpecDie) DieWith(fn func(d *ServiceSpecDie)) *ServiceSpecDie {
+func (d *ServiceSpecDie) DieWith(fns ...func(d *ServiceSpecDie)) *ServiceSpecDie {
 	nd := ServiceSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -26625,9 +27109,13 @@ func (d *ServicePortDie) DieStampAt(jp string, fn interface{}) *ServicePortDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServicePortDie) DieWith(fn func(d *ServicePortDie)) *ServicePortDie {
+func (d *ServicePortDie) DieWith(fns ...func(d *ServicePortDie)) *ServicePortDie {
 	nd := ServicePortBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -26859,9 +27347,13 @@ func (d *SessionAffinityConfigDie) DieStampAt(jp string, fn interface{}) *Sessio
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SessionAffinityConfigDie) DieWith(fn func(d *SessionAffinityConfigDie)) *SessionAffinityConfigDie {
+func (d *SessionAffinityConfigDie) DieWith(fns ...func(d *SessionAffinityConfigDie)) *SessionAffinityConfigDie {
 	nd := SessionAffinityConfigBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -27044,9 +27536,13 @@ func (d *ClientIPConfigDie) DieStampAt(jp string, fn interface{}) *ClientIPConfi
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ClientIPConfigDie) DieWith(fn func(d *ClientIPConfigDie)) *ClientIPConfigDie {
+func (d *ClientIPConfigDie) DieWith(fns ...func(d *ClientIPConfigDie)) *ClientIPConfigDie {
 	nd := ClientIPConfigBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -27229,9 +27725,13 @@ func (d *ServiceStatusDie) DieStampAt(jp string, fn interface{}) *ServiceStatusD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServiceStatusDie) DieWith(fn func(d *ServiceStatusDie)) *ServiceStatusDie {
+func (d *ServiceStatusDie) DieWith(fns ...func(d *ServiceStatusDie)) *ServiceStatusDie {
 	nd := ServiceStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -27421,9 +27921,13 @@ func (d *LoadBalancerStatusDie) DieStampAt(jp string, fn interface{}) *LoadBalan
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LoadBalancerStatusDie) DieWith(fn func(d *LoadBalancerStatusDie)) *LoadBalancerStatusDie {
+func (d *LoadBalancerStatusDie) DieWith(fns ...func(d *LoadBalancerStatusDie)) *LoadBalancerStatusDie {
 	nd := LoadBalancerStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -27606,9 +28110,13 @@ func (d *LoadBalancerIngressDie) DieStampAt(jp string, fn interface{}) *LoadBala
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LoadBalancerIngressDie) DieWith(fn func(d *LoadBalancerIngressDie)) *LoadBalancerIngressDie {
+func (d *LoadBalancerIngressDie) DieWith(fns ...func(d *LoadBalancerIngressDie)) *LoadBalancerIngressDie {
 	nd := LoadBalancerIngressBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -27805,9 +28313,13 @@ func (d *PortStatusDie) DieStampAt(jp string, fn interface{}) *PortStatusDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PortStatusDie) DieWith(fn func(d *PortStatusDie)) *PortStatusDie {
+func (d *PortStatusDie) DieWith(fns ...func(d *PortStatusDie)) *PortStatusDie {
 	nd := PortStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -28019,9 +28531,13 @@ func (d *ServiceAccountDie) DieStampAt(jp string, fn interface{}) *ServiceAccoun
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServiceAccountDie) DieWith(fn func(d *ServiceAccountDie)) *ServiceAccountDie {
+func (d *ServiceAccountDie) DieWith(fns ...func(d *ServiceAccountDie)) *ServiceAccountDie {
 	nd := ServiceAccountBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -28270,9 +28786,13 @@ func (d *VolumeDie) DieStampAt(jp string, fn interface{}) *VolumeDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeDie) DieWith(fn func(d *VolumeDie)) *VolumeDie {
+func (d *VolumeDie) DieWith(fns ...func(d *VolumeDie)) *VolumeDie {
 	nd := VolumeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -28462,9 +28982,13 @@ func (d *HostPathVolumeSourceDie) DieStampAt(jp string, fn interface{}) *HostPat
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *HostPathVolumeSourceDie) DieWith(fn func(d *HostPathVolumeSourceDie)) *HostPathVolumeSourceDie {
+func (d *HostPathVolumeSourceDie) DieWith(fns ...func(d *HostPathVolumeSourceDie)) *HostPathVolumeSourceDie {
 	nd := HostPathVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -28654,9 +29178,13 @@ func (d *EmptyDirVolumeSourceDie) DieStampAt(jp string, fn interface{}) *EmptyDi
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EmptyDirVolumeSourceDie) DieWith(fn func(d *EmptyDirVolumeSourceDie)) *EmptyDirVolumeSourceDie {
+func (d *EmptyDirVolumeSourceDie) DieWith(fns ...func(d *EmptyDirVolumeSourceDie)) *EmptyDirVolumeSourceDie {
 	nd := EmptyDirVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -28846,9 +29374,13 @@ func (d *GCEPersistentDiskVolumeSourceDie) DieStampAt(jp string, fn interface{})
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GCEPersistentDiskVolumeSourceDie) DieWith(fn func(d *GCEPersistentDiskVolumeSourceDie)) *GCEPersistentDiskVolumeSourceDie {
+func (d *GCEPersistentDiskVolumeSourceDie) DieWith(fns ...func(d *GCEPersistentDiskVolumeSourceDie)) *GCEPersistentDiskVolumeSourceDie {
 	nd := GCEPersistentDiskVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -29052,9 +29584,13 @@ func (d *AWSElasticBlockStoreVolumeSourceDie) DieStampAt(jp string, fn interface
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AWSElasticBlockStoreVolumeSourceDie) DieWith(fn func(d *AWSElasticBlockStoreVolumeSourceDie)) *AWSElasticBlockStoreVolumeSourceDie {
+func (d *AWSElasticBlockStoreVolumeSourceDie) DieWith(fns ...func(d *AWSElasticBlockStoreVolumeSourceDie)) *AWSElasticBlockStoreVolumeSourceDie {
 	nd := AWSElasticBlockStoreVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -29258,9 +29794,13 @@ func (d *GitRepoVolumeSourceDie) DieStampAt(jp string, fn interface{}) *GitRepoV
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GitRepoVolumeSourceDie) DieWith(fn func(d *GitRepoVolumeSourceDie)) *GitRepoVolumeSourceDie {
+func (d *GitRepoVolumeSourceDie) DieWith(fns ...func(d *GitRepoVolumeSourceDie)) *GitRepoVolumeSourceDie {
 	nd := GitRepoVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -29457,9 +29997,13 @@ func (d *SecretVolumeSourceDie) DieStampAt(jp string, fn interface{}) *SecretVol
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SecretVolumeSourceDie) DieWith(fn func(d *SecretVolumeSourceDie)) *SecretVolumeSourceDie {
+func (d *SecretVolumeSourceDie) DieWith(fns ...func(d *SecretVolumeSourceDie)) *SecretVolumeSourceDie {
 	nd := SecretVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -29663,9 +30207,13 @@ func (d *NFSVolumeSourceDie) DieStampAt(jp string, fn interface{}) *NFSVolumeSou
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NFSVolumeSourceDie) DieWith(fn func(d *NFSVolumeSourceDie)) *NFSVolumeSourceDie {
+func (d *NFSVolumeSourceDie) DieWith(fns ...func(d *NFSVolumeSourceDie)) *NFSVolumeSourceDie {
 	nd := NFSVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -29862,9 +30410,13 @@ func (d *ISCSIVolumeSourceDie) DieStampAt(jp string, fn interface{}) *ISCSIVolum
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ISCSIVolumeSourceDie) DieWith(fn func(d *ISCSIVolumeSourceDie)) *ISCSIVolumeSourceDie {
+func (d *ISCSIVolumeSourceDie) DieWith(fns ...func(d *ISCSIVolumeSourceDie)) *ISCSIVolumeSourceDie {
 	nd := ISCSIVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -30117,9 +30669,13 @@ func (d *GlusterfsVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Gluste
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GlusterfsVolumeSourceDie) DieWith(fn func(d *GlusterfsVolumeSourceDie)) *GlusterfsVolumeSourceDie {
+func (d *GlusterfsVolumeSourceDie) DieWith(fns ...func(d *GlusterfsVolumeSourceDie)) *GlusterfsVolumeSourceDie {
 	nd := GlusterfsVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -30316,9 +30872,13 @@ func (d *PersistentVolumeClaimVolumeSourceDie) DieStampAt(jp string, fn interfac
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PersistentVolumeClaimVolumeSourceDie) DieWith(fn func(d *PersistentVolumeClaimVolumeSourceDie)) *PersistentVolumeClaimVolumeSourceDie {
+func (d *PersistentVolumeClaimVolumeSourceDie) DieWith(fns ...func(d *PersistentVolumeClaimVolumeSourceDie)) *PersistentVolumeClaimVolumeSourceDie {
 	nd := PersistentVolumeClaimVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -30508,9 +31068,13 @@ func (d *RBDVolumeSourceDie) DieStampAt(jp string, fn interface{}) *RBDVolumeSou
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RBDVolumeSourceDie) DieWith(fn func(d *RBDVolumeSourceDie)) *RBDVolumeSourceDie {
+func (d *RBDVolumeSourceDie) DieWith(fns ...func(d *RBDVolumeSourceDie)) *RBDVolumeSourceDie {
 	nd := RBDVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -30742,9 +31306,13 @@ func (d *FlexVolumeSourceDie) DieStampAt(jp string, fn interface{}) *FlexVolumeS
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *FlexVolumeSourceDie) DieWith(fn func(d *FlexVolumeSourceDie)) *FlexVolumeSourceDie {
+func (d *FlexVolumeSourceDie) DieWith(fns ...func(d *FlexVolumeSourceDie)) *FlexVolumeSourceDie {
 	nd := FlexVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -30955,9 +31523,13 @@ func (d *CinderVolumeSourceDie) DieStampAt(jp string, fn interface{}) *CinderVol
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CinderVolumeSourceDie) DieWith(fn func(d *CinderVolumeSourceDie)) *CinderVolumeSourceDie {
+func (d *CinderVolumeSourceDie) DieWith(fns ...func(d *CinderVolumeSourceDie)) *CinderVolumeSourceDie {
 	nd := CinderVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -31161,9 +31733,13 @@ func (d *CephFSVolumeSourceDie) DieStampAt(jp string, fn interface{}) *CephFSVol
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CephFSVolumeSourceDie) DieWith(fn func(d *CephFSVolumeSourceDie)) *CephFSVolumeSourceDie {
+func (d *CephFSVolumeSourceDie) DieWith(fns ...func(d *CephFSVolumeSourceDie)) *CephFSVolumeSourceDie {
 	nd := CephFSVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -31381,9 +31957,13 @@ func (d *FlockerVolumeSourceDie) DieStampAt(jp string, fn interface{}) *FlockerV
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *FlockerVolumeSourceDie) DieWith(fn func(d *FlockerVolumeSourceDie)) *FlockerVolumeSourceDie {
+func (d *FlockerVolumeSourceDie) DieWith(fns ...func(d *FlockerVolumeSourceDie)) *FlockerVolumeSourceDie {
 	nd := FlockerVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -31573,9 +32153,13 @@ func (d *DownwardAPIVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Down
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DownwardAPIVolumeSourceDie) DieWith(fn func(d *DownwardAPIVolumeSourceDie)) *DownwardAPIVolumeSourceDie {
+func (d *DownwardAPIVolumeSourceDie) DieWith(fns ...func(d *DownwardAPIVolumeSourceDie)) *DownwardAPIVolumeSourceDie {
 	nd := DownwardAPIVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -31765,9 +32349,13 @@ func (d *DownwardAPIVolumeFileDie) DieStampAt(jp string, fn interface{}) *Downwa
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DownwardAPIVolumeFileDie) DieWith(fn func(d *DownwardAPIVolumeFileDie)) *DownwardAPIVolumeFileDie {
+func (d *DownwardAPIVolumeFileDie) DieWith(fns ...func(d *DownwardAPIVolumeFileDie)) *DownwardAPIVolumeFileDie {
 	nd := DownwardAPIVolumeFileBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -31971,9 +32559,13 @@ func (d *FCVolumeSourceDie) DieStampAt(jp string, fn interface{}) *FCVolumeSourc
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *FCVolumeSourceDie) DieWith(fn func(d *FCVolumeSourceDie)) *FCVolumeSourceDie {
+func (d *FCVolumeSourceDie) DieWith(fns ...func(d *FCVolumeSourceDie)) *FCVolumeSourceDie {
 	nd := FCVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -32184,9 +32776,13 @@ func (d *AzureFileVolumeSourceDie) DieStampAt(jp string, fn interface{}) *AzureF
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AzureFileVolumeSourceDie) DieWith(fn func(d *AzureFileVolumeSourceDie)) *AzureFileVolumeSourceDie {
+func (d *AzureFileVolumeSourceDie) DieWith(fns ...func(d *AzureFileVolumeSourceDie)) *AzureFileVolumeSourceDie {
 	nd := AzureFileVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -32383,9 +32979,13 @@ func (d *ConfigMapVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Config
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ConfigMapVolumeSourceDie) DieWith(fn func(d *ConfigMapVolumeSourceDie)) *ConfigMapVolumeSourceDie {
+func (d *ConfigMapVolumeSourceDie) DieWith(fns ...func(d *ConfigMapVolumeSourceDie)) *ConfigMapVolumeSourceDie {
 	nd := ConfigMapVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -32588,9 +33188,13 @@ func (d *VsphereVirtualDiskVolumeSourceDie) DieStampAt(jp string, fn interface{}
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VsphereVirtualDiskVolumeSourceDie) DieWith(fn func(d *VsphereVirtualDiskVolumeSourceDie)) *VsphereVirtualDiskVolumeSourceDie {
+func (d *VsphereVirtualDiskVolumeSourceDie) DieWith(fns ...func(d *VsphereVirtualDiskVolumeSourceDie)) *VsphereVirtualDiskVolumeSourceDie {
 	nd := VsphereVirtualDiskVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -32794,9 +33398,13 @@ func (d *QuobyteVolumeSourceDie) DieStampAt(jp string, fn interface{}) *QuobyteV
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *QuobyteVolumeSourceDie) DieWith(fn func(d *QuobyteVolumeSourceDie)) *QuobyteVolumeSourceDie {
+func (d *QuobyteVolumeSourceDie) DieWith(fns ...func(d *QuobyteVolumeSourceDie)) *QuobyteVolumeSourceDie {
 	nd := QuobyteVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -33014,9 +33622,13 @@ func (d *AzureDiskVolumeSourceDie) DieStampAt(jp string, fn interface{}) *AzureD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AzureDiskVolumeSourceDie) DieWith(fn func(d *AzureDiskVolumeSourceDie)) *AzureDiskVolumeSourceDie {
+func (d *AzureDiskVolumeSourceDie) DieWith(fns ...func(d *AzureDiskVolumeSourceDie)) *AzureDiskVolumeSourceDie {
 	nd := AzureDiskVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -33234,9 +33846,13 @@ func (d *PhotonPersistentDiskVolumeSourceDie) DieStampAt(jp string, fn interface
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PhotonPersistentDiskVolumeSourceDie) DieWith(fn func(d *PhotonPersistentDiskVolumeSourceDie)) *PhotonPersistentDiskVolumeSourceDie {
+func (d *PhotonPersistentDiskVolumeSourceDie) DieWith(fns ...func(d *PhotonPersistentDiskVolumeSourceDie)) *PhotonPersistentDiskVolumeSourceDie {
 	nd := PhotonPersistentDiskVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -33426,9 +34042,13 @@ func (d *ProjectedVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Projec
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ProjectedVolumeSourceDie) DieWith(fn func(d *ProjectedVolumeSourceDie)) *ProjectedVolumeSourceDie {
+func (d *ProjectedVolumeSourceDie) DieWith(fns ...func(d *ProjectedVolumeSourceDie)) *ProjectedVolumeSourceDie {
 	nd := ProjectedVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -33618,9 +34238,13 @@ func (d *VolumeProjectionDie) DieStampAt(jp string, fn interface{}) *VolumeProje
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeProjectionDie) DieWith(fn func(d *VolumeProjectionDie)) *VolumeProjectionDie {
+func (d *VolumeProjectionDie) DieWith(fns ...func(d *VolumeProjectionDie)) *VolumeProjectionDie {
 	nd := VolumeProjectionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -33824,9 +34448,13 @@ func (d *SecretProjectionDie) DieStampAt(jp string, fn interface{}) *SecretProje
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SecretProjectionDie) DieWith(fn func(d *SecretProjectionDie)) *SecretProjectionDie {
+func (d *SecretProjectionDie) DieWith(fns ...func(d *SecretProjectionDie)) *SecretProjectionDie {
 	nd := SecretProjectionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -34022,9 +34650,13 @@ func (d *DownwardAPIProjectionDie) DieStampAt(jp string, fn interface{}) *Downwa
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DownwardAPIProjectionDie) DieWith(fn func(d *DownwardAPIProjectionDie)) *DownwardAPIProjectionDie {
+func (d *DownwardAPIProjectionDie) DieWith(fns ...func(d *DownwardAPIProjectionDie)) *DownwardAPIProjectionDie {
 	nd := DownwardAPIProjectionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -34207,9 +34839,13 @@ func (d *ConfigMapProjectionDie) DieStampAt(jp string, fn interface{}) *ConfigMa
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ConfigMapProjectionDie) DieWith(fn func(d *ConfigMapProjectionDie)) *ConfigMapProjectionDie {
+func (d *ConfigMapProjectionDie) DieWith(fns ...func(d *ConfigMapProjectionDie)) *ConfigMapProjectionDie {
 	nd := ConfigMapProjectionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -34405,9 +35041,13 @@ func (d *ServiceAccountTokenProjectionDie) DieStampAt(jp string, fn interface{})
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServiceAccountTokenProjectionDie) DieWith(fn func(d *ServiceAccountTokenProjectionDie)) *ServiceAccountTokenProjectionDie {
+func (d *ServiceAccountTokenProjectionDie) DieWith(fns ...func(d *ServiceAccountTokenProjectionDie)) *ServiceAccountTokenProjectionDie {
 	nd := ServiceAccountTokenProjectionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -34604,9 +35244,13 @@ func (d *PortworxVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Portwor
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PortworxVolumeSourceDie) DieWith(fn func(d *PortworxVolumeSourceDie)) *PortworxVolumeSourceDie {
+func (d *PortworxVolumeSourceDie) DieWith(fns ...func(d *PortworxVolumeSourceDie)) *PortworxVolumeSourceDie {
 	nd := PortworxVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -34803,9 +35447,13 @@ func (d *ScaleIOVolumeSourceDie) DieStampAt(jp string, fn interface{}) *ScaleIOV
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ScaleIOVolumeSourceDie) DieWith(fn func(d *ScaleIOVolumeSourceDie)) *ScaleIOVolumeSourceDie {
+func (d *ScaleIOVolumeSourceDie) DieWith(fns ...func(d *ScaleIOVolumeSourceDie)) *ScaleIOVolumeSourceDie {
 	nd := ScaleIOVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -35051,9 +35699,13 @@ func (d *StorageOSVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Storag
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StorageOSVolumeSourceDie) DieWith(fn func(d *StorageOSVolumeSourceDie)) *StorageOSVolumeSourceDie {
+func (d *StorageOSVolumeSourceDie) DieWith(fns ...func(d *StorageOSVolumeSourceDie)) *StorageOSVolumeSourceDie {
 	nd := StorageOSVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -35264,9 +35916,13 @@ func (d *CSIVolumeSourceDie) DieStampAt(jp string, fn interface{}) *CSIVolumeSou
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CSIVolumeSourceDie) DieWith(fn func(d *CSIVolumeSourceDie)) *CSIVolumeSourceDie {
+func (d *CSIVolumeSourceDie) DieWith(fns ...func(d *CSIVolumeSourceDie)) *CSIVolumeSourceDie {
 	nd := CSIVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -35477,9 +36133,13 @@ func (d *EphemeralVolumeSourceDie) DieStampAt(jp string, fn interface{}) *Epheme
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EphemeralVolumeSourceDie) DieWith(fn func(d *EphemeralVolumeSourceDie)) *EphemeralVolumeSourceDie {
+func (d *EphemeralVolumeSourceDie) DieWith(fns ...func(d *EphemeralVolumeSourceDie)) *EphemeralVolumeSourceDie {
 	nd := EphemeralVolumeSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -35668,9 +36328,13 @@ func (d *KeyToPathDie) DieStampAt(jp string, fn interface{}) *KeyToPathDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *KeyToPathDie) DieWith(fn func(d *KeyToPathDie)) *KeyToPathDie {
+func (d *KeyToPathDie) DieWith(fns ...func(d *KeyToPathDie)) *KeyToPathDie {
 	nd := KeyToPathBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/events/v1/zz_generated.die.go
+++ b/apis/events/v1/zz_generated.die.go
@@ -215,9 +215,13 @@ func (d *EventDie) DieStampAt(jp string, fn interface{}) *EventDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EventDie) DieWith(fn func(d *EventDie)) *EventDie {
+func (d *EventDie) DieWith(fns ...func(d *EventDie)) *EventDie {
 	nd := EventBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -543,9 +547,13 @@ func (d *EventSeriesDie) DieStampAt(jp string, fn interface{}) *EventSeriesDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *EventSeriesDie) DieWith(fn func(d *EventSeriesDie)) *EventSeriesDie {
+func (d *EventSeriesDie) DieWith(fns ...func(d *EventSeriesDie)) *EventSeriesDie {
 	nd := EventSeriesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/meta/v1/zz_generated.die.go
+++ b/apis/meta/v1/zz_generated.die.go
@@ -196,9 +196,13 @@ func (d *ConditionDie) DieStampAt(jp string, fn interface{}) *ConditionDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ConditionDie) DieWith(fn func(d *ConditionDie)) *ConditionDie {
+func (d *ConditionDie) DieWith(fns ...func(d *ConditionDie)) *ConditionDie {
 	nd := ConditionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -416,9 +420,13 @@ func (d *GroupResourceDie) DieStampAt(jp string, fn interface{}) *GroupResourceD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GroupResourceDie) DieWith(fn func(d *GroupResourceDie)) *GroupResourceDie {
+func (d *GroupResourceDie) DieWith(fns ...func(d *GroupResourceDie)) *GroupResourceDie {
 	nd := GroupResourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -606,9 +614,13 @@ func (d *GroupVersionDie) DieStampAt(jp string, fn interface{}) *GroupVersionDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GroupVersionDie) DieWith(fn func(d *GroupVersionDie)) *GroupVersionDie {
+func (d *GroupVersionDie) DieWith(fns ...func(d *GroupVersionDie)) *GroupVersionDie {
 	nd := GroupVersionBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -796,9 +808,13 @@ func (d *GroupVersionKindDie) DieStampAt(jp string, fn interface{}) *GroupVersio
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GroupVersionKindDie) DieWith(fn func(d *GroupVersionKindDie)) *GroupVersionKindDie {
+func (d *GroupVersionKindDie) DieWith(fns ...func(d *GroupVersionKindDie)) *GroupVersionKindDie {
 	nd := GroupVersionKindBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -992,9 +1008,13 @@ func (d *GroupVersionResourceDie) DieStampAt(jp string, fn interface{}) *GroupVe
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GroupVersionResourceDie) DieWith(fn func(d *GroupVersionResourceDie)) *GroupVersionResourceDie {
+func (d *GroupVersionResourceDie) DieWith(fns ...func(d *GroupVersionResourceDie)) *GroupVersionResourceDie {
 	nd := GroupVersionResourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1188,9 +1208,13 @@ func (d *GroupVersionForDiscoveryDie) DieStampAt(jp string, fn interface{}) *Gro
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *GroupVersionForDiscoveryDie) DieWith(fn func(d *GroupVersionForDiscoveryDie)) *GroupVersionForDiscoveryDie {
+func (d *GroupVersionForDiscoveryDie) DieWith(fns ...func(d *GroupVersionForDiscoveryDie)) *GroupVersionForDiscoveryDie {
 	nd := GroupVersionForDiscoveryBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1380,9 +1404,13 @@ func (d *ListMetaDie) DieStampAt(jp string, fn interface{}) *ListMetaDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ListMetaDie) DieWith(fn func(d *ListMetaDie)) *ListMetaDie {
+func (d *ListMetaDie) DieWith(fns ...func(d *ListMetaDie)) *ListMetaDie {
 	nd := ListMetaBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1586,9 +1614,13 @@ func (d *ObjectMetaDie) DieStampAt(jp string, fn interface{}) *ObjectMetaDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ObjectMetaDie) DieWith(fn func(d *ObjectMetaDie)) *ObjectMetaDie {
+func (d *ObjectMetaDie) DieWith(fns ...func(d *ObjectMetaDie)) *ObjectMetaDie {
 	nd := ObjectMetaBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1883,9 +1915,13 @@ func (d *ManagedFieldsEntryDie) DieStampAt(jp string, fn interface{}) *ManagedFi
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ManagedFieldsEntryDie) DieWith(fn func(d *ManagedFieldsEntryDie)) *ManagedFieldsEntryDie {
+func (d *ManagedFieldsEntryDie) DieWith(fns ...func(d *ManagedFieldsEntryDie)) *ManagedFieldsEntryDie {
 	nd := ManagedFieldsEntryBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2110,9 +2146,13 @@ func (d *LabelSelectorDie) DieStampAt(jp string, fn interface{}) *LabelSelectorD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *LabelSelectorDie) DieWith(fn func(d *LabelSelectorDie)) *LabelSelectorDie {
+func (d *LabelSelectorDie) DieWith(fns ...func(d *LabelSelectorDie)) *LabelSelectorDie {
 	nd := LabelSelectorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2302,9 +2342,13 @@ func (d *StatusDie) DieStampAt(jp string, fn interface{}) *StatusDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StatusDie) DieWith(fn func(d *StatusDie)) *StatusDie {
+func (d *StatusDie) DieWith(fns ...func(d *StatusDie)) *StatusDie {
 	nd := StatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2528,9 +2572,13 @@ func (d *StatusDetailsDie) DieStampAt(jp string, fn interface{}) *StatusDetailsD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StatusDetailsDie) DieWith(fn func(d *StatusDetailsDie)) *StatusDetailsDie {
+func (d *StatusDetailsDie) DieWith(fns ...func(d *StatusDetailsDie)) *StatusDetailsDie {
 	nd := StatusDetailsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2748,9 +2796,13 @@ func (d *StatusCauseDie) DieStampAt(jp string, fn interface{}) *StatusCauseDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StatusCauseDie) DieWith(fn func(d *StatusCauseDie)) *StatusCauseDie {
+func (d *StatusCauseDie) DieWith(fns ...func(d *StatusCauseDie)) *StatusCauseDie {
 	nd := StatusCauseBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/networking/v1/zz_generated.die.go
+++ b/apis/networking/v1/zz_generated.die.go
@@ -216,9 +216,13 @@ func (d *IngressDie) DieStampAt(jp string, fn interface{}) *IngressDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressDie) DieWith(fn func(d *IngressDie)) *IngressDie {
+func (d *IngressDie) DieWith(fns ...func(d *IngressDie)) *IngressDie {
 	nd := IngressBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -478,9 +482,13 @@ func (d *IngressSpecDie) DieStampAt(jp string, fn interface{}) *IngressSpecDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressSpecDie) DieWith(fn func(d *IngressSpecDie)) *IngressSpecDie {
+func (d *IngressSpecDie) DieWith(fns ...func(d *IngressSpecDie)) *IngressSpecDie {
 	nd := IngressSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -684,9 +692,13 @@ func (d *IngressBackendDie) DieStampAt(jp string, fn interface{}) *IngressBacken
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressBackendDie) DieWith(fn func(d *IngressBackendDie)) *IngressBackendDie {
+func (d *IngressBackendDie) DieWith(fns ...func(d *IngressBackendDie)) *IngressBackendDie {
 	nd := IngressBackendBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -876,9 +888,13 @@ func (d *IngressServiceBackendDie) DieStampAt(jp string, fn interface{}) *Ingres
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressServiceBackendDie) DieWith(fn func(d *IngressServiceBackendDie)) *IngressServiceBackendDie {
+func (d *IngressServiceBackendDie) DieWith(fns ...func(d *IngressServiceBackendDie)) *IngressServiceBackendDie {
 	nd := IngressServiceBackendBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1068,9 +1084,13 @@ func (d *ServiceBackendPortDie) DieStampAt(jp string, fn interface{}) *ServiceBa
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *ServiceBackendPortDie) DieWith(fn func(d *ServiceBackendPortDie)) *ServiceBackendPortDie {
+func (d *ServiceBackendPortDie) DieWith(fns ...func(d *ServiceBackendPortDie)) *ServiceBackendPortDie {
 	nd := ServiceBackendPortBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1260,9 +1280,13 @@ func (d *IngressTLSDie) DieStampAt(jp string, fn interface{}) *IngressTLSDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressTLSDie) DieWith(fn func(d *IngressTLSDie)) *IngressTLSDie {
+func (d *IngressTLSDie) DieWith(fns ...func(d *IngressTLSDie)) *IngressTLSDie {
 	nd := IngressTLSBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1452,9 +1476,13 @@ func (d *IngressRuleDie) DieStampAt(jp string, fn interface{}) *IngressRuleDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressRuleDie) DieWith(fn func(d *IngressRuleDie)) *IngressRuleDie {
+func (d *IngressRuleDie) DieWith(fns ...func(d *IngressRuleDie)) *IngressRuleDie {
 	nd := IngressRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1646,9 +1674,13 @@ func (d *HTTPIngressRuleValueDie) DieStampAt(jp string, fn interface{}) *HTTPIng
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *HTTPIngressRuleValueDie) DieWith(fn func(d *HTTPIngressRuleValueDie)) *HTTPIngressRuleValueDie {
+func (d *HTTPIngressRuleValueDie) DieWith(fns ...func(d *HTTPIngressRuleValueDie)) *HTTPIngressRuleValueDie {
 	nd := HTTPIngressRuleValueBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1831,9 +1863,13 @@ func (d *HTTPIngressPathDie) DieStampAt(jp string, fn interface{}) *HTTPIngressP
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *HTTPIngressPathDie) DieWith(fn func(d *HTTPIngressPathDie)) *HTTPIngressPathDie {
+func (d *HTTPIngressPathDie) DieWith(fns ...func(d *HTTPIngressPathDie)) *HTTPIngressPathDie {
 	nd := HTTPIngressPathBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2030,9 +2066,13 @@ func (d *IngressStatusDie) DieStampAt(jp string, fn interface{}) *IngressStatusD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressStatusDie) DieWith(fn func(d *IngressStatusDie)) *IngressStatusDie {
+func (d *IngressStatusDie) DieWith(fns ...func(d *IngressStatusDie)) *IngressStatusDie {
 	nd := IngressStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2215,9 +2255,13 @@ func (d *IngressLoadBalancerStatusDie) DieStampAt(jp string, fn interface{}) *In
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressLoadBalancerStatusDie) DieWith(fn func(d *IngressLoadBalancerStatusDie)) *IngressLoadBalancerStatusDie {
+func (d *IngressLoadBalancerStatusDie) DieWith(fns ...func(d *IngressLoadBalancerStatusDie)) *IngressLoadBalancerStatusDie {
 	nd := IngressLoadBalancerStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2400,9 +2444,13 @@ func (d *IngressLoadBalancerIngressDie) DieStampAt(jp string, fn interface{}) *I
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressLoadBalancerIngressDie) DieWith(fn func(d *IngressLoadBalancerIngressDie)) *IngressLoadBalancerIngressDie {
+func (d *IngressLoadBalancerIngressDie) DieWith(fns ...func(d *IngressLoadBalancerIngressDie)) *IngressLoadBalancerIngressDie {
 	nd := IngressLoadBalancerIngressBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2599,9 +2647,13 @@ func (d *IngressPortStatusDie) DieStampAt(jp string, fn interface{}) *IngressPor
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressPortStatusDie) DieWith(fn func(d *IngressPortStatusDie)) *IngressPortStatusDie {
+func (d *IngressPortStatusDie) DieWith(fns ...func(d *IngressPortStatusDie)) *IngressPortStatusDie {
 	nd := IngressPortStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2813,9 +2865,13 @@ func (d *IngressClassDie) DieStampAt(jp string, fn interface{}) *IngressClassDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressClassDie) DieWith(fn func(d *IngressClassDie)) *IngressClassDie {
+func (d *IngressClassDie) DieWith(fns ...func(d *IngressClassDie)) *IngressClassDie {
 	nd := IngressClassBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3059,9 +3115,13 @@ func (d *IngressClassSpecDie) DieStampAt(jp string, fn interface{}) *IngressClas
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressClassSpecDie) DieWith(fn func(d *IngressClassSpecDie)) *IngressClassSpecDie {
+func (d *IngressClassSpecDie) DieWith(fns ...func(d *IngressClassSpecDie)) *IngressClassSpecDie {
 	nd := IngressClassSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3251,9 +3311,13 @@ func (d *IngressClassParametersReferenceDie) DieStampAt(jp string, fn interface{
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IngressClassParametersReferenceDie) DieWith(fn func(d *IngressClassParametersReferenceDie)) *IngressClassParametersReferenceDie {
+func (d *IngressClassParametersReferenceDie) DieWith(fns ...func(d *IngressClassParametersReferenceDie)) *IngressClassParametersReferenceDie {
 	nd := IngressClassParametersReferenceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3479,9 +3543,13 @@ func (d *NetworkPolicyDie) DieStampAt(jp string, fn interface{}) *NetworkPolicyD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NetworkPolicyDie) DieWith(fn func(d *NetworkPolicyDie)) *NetworkPolicyDie {
+func (d *NetworkPolicyDie) DieWith(fns ...func(d *NetworkPolicyDie)) *NetworkPolicyDie {
 	nd := NetworkPolicyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3741,9 +3809,13 @@ func (d *NetworkPolicySpecDie) DieStampAt(jp string, fn interface{}) *NetworkPol
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NetworkPolicySpecDie) DieWith(fn func(d *NetworkPolicySpecDie)) *NetworkPolicySpecDie {
+func (d *NetworkPolicySpecDie) DieWith(fns ...func(d *NetworkPolicySpecDie)) *NetworkPolicySpecDie {
 	nd := NetworkPolicySpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -3947,9 +4019,13 @@ func (d *NetworkPolicyIngressRuleDie) DieStampAt(jp string, fn interface{}) *Net
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NetworkPolicyIngressRuleDie) DieWith(fn func(d *NetworkPolicyIngressRuleDie)) *NetworkPolicyIngressRuleDie {
+func (d *NetworkPolicyIngressRuleDie) DieWith(fns ...func(d *NetworkPolicyIngressRuleDie)) *NetworkPolicyIngressRuleDie {
 	nd := NetworkPolicyIngressRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4139,9 +4215,13 @@ func (d *NetworkPolicyEgressRuleDie) DieStampAt(jp string, fn interface{}) *Netw
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NetworkPolicyEgressRuleDie) DieWith(fn func(d *NetworkPolicyEgressRuleDie)) *NetworkPolicyEgressRuleDie {
+func (d *NetworkPolicyEgressRuleDie) DieWith(fns ...func(d *NetworkPolicyEgressRuleDie)) *NetworkPolicyEgressRuleDie {
 	nd := NetworkPolicyEgressRuleBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4331,9 +4411,13 @@ func (d *NetworkPolicyPortDie) DieStampAt(jp string, fn interface{}) *NetworkPol
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NetworkPolicyPortDie) DieWith(fn func(d *NetworkPolicyPortDie)) *NetworkPolicyPortDie {
+func (d *NetworkPolicyPortDie) DieWith(fns ...func(d *NetworkPolicyPortDie)) *NetworkPolicyPortDie {
 	nd := NetworkPolicyPortBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4544,9 +4628,13 @@ func (d *NetworkPolicyPeerDie) DieStampAt(jp string, fn interface{}) *NetworkPol
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NetworkPolicyPeerDie) DieWith(fn func(d *NetworkPolicyPeerDie)) *NetworkPolicyPeerDie {
+func (d *NetworkPolicyPeerDie) DieWith(fns ...func(d *NetworkPolicyPeerDie)) *NetworkPolicyPeerDie {
 	nd := NetworkPolicyPeerBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4747,9 +4835,13 @@ func (d *IPBlockDie) DieStampAt(jp string, fn interface{}) *IPBlockDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IPBlockDie) DieWith(fn func(d *IPBlockDie)) *IPBlockDie {
+func (d *IPBlockDie) DieWith(fns ...func(d *IPBlockDie)) *IPBlockDie {
 	nd := IPBlockBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -4939,9 +5031,13 @@ func (d *NetworkPolicyStatusDie) DieStampAt(jp string, fn interface{}) *NetworkP
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *NetworkPolicyStatusDie) DieWith(fn func(d *NetworkPolicyStatusDie)) *NetworkPolicyStatusDie {
+func (d *NetworkPolicyStatusDie) DieWith(fns ...func(d *NetworkPolicyStatusDie)) *NetworkPolicyStatusDie {
 	nd := NetworkPolicyStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/node/v1/zz_generated.die.go
+++ b/apis/node/v1/zz_generated.die.go
@@ -214,9 +214,13 @@ func (d *RuntimeClassDie) DieStampAt(jp string, fn interface{}) *RuntimeClassDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RuntimeClassDie) DieWith(fn func(d *RuntimeClassDie)) *RuntimeClassDie {
+func (d *RuntimeClassDie) DieWith(fns ...func(d *RuntimeClassDie)) *RuntimeClassDie {
 	nd := RuntimeClassBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -465,9 +469,13 @@ func (d *OverheadDie) DieStampAt(jp string, fn interface{}) *OverheadDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *OverheadDie) DieWith(fn func(d *OverheadDie)) *OverheadDie {
+func (d *OverheadDie) DieWith(fns ...func(d *OverheadDie)) *OverheadDie {
 	nd := OverheadBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -650,9 +658,13 @@ func (d *SchedulingDie) DieStampAt(jp string, fn interface{}) *SchedulingDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SchedulingDie) DieWith(fn func(d *SchedulingDie)) *SchedulingDie {
+func (d *SchedulingDie) DieWith(fns ...func(d *SchedulingDie)) *SchedulingDie {
 	nd := SchedulingBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/policy/v1/zz_generated.die.go
+++ b/apis/policy/v1/zz_generated.die.go
@@ -215,9 +215,13 @@ func (d *PodDisruptionBudgetDie) DieStampAt(jp string, fn interface{}) *PodDisru
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodDisruptionBudgetDie) DieWith(fn func(d *PodDisruptionBudgetDie)) *PodDisruptionBudgetDie {
+func (d *PodDisruptionBudgetDie) DieWith(fns ...func(d *PodDisruptionBudgetDie)) *PodDisruptionBudgetDie {
 	nd := PodDisruptionBudgetBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -477,9 +481,13 @@ func (d *PodDisruptionBudgetSpecDie) DieStampAt(jp string, fn interface{}) *PodD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodDisruptionBudgetSpecDie) DieWith(fn func(d *PodDisruptionBudgetSpecDie)) *PodDisruptionBudgetSpecDie {
+func (d *PodDisruptionBudgetSpecDie) DieWith(fns ...func(d *PodDisruptionBudgetSpecDie)) *PodDisruptionBudgetSpecDie {
 	nd := PodDisruptionBudgetSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -721,9 +729,13 @@ func (d *PodDisruptionBudgetStatusDie) DieStampAt(jp string, fn interface{}) *Po
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodDisruptionBudgetStatusDie) DieWith(fn func(d *PodDisruptionBudgetStatusDie)) *PodDisruptionBudgetStatusDie {
+func (d *PodDisruptionBudgetStatusDie) DieWith(fns ...func(d *PodDisruptionBudgetStatusDie)) *PodDisruptionBudgetStatusDie {
 	nd := PodDisruptionBudgetStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/policy/v1beta1/zz_generated.die.go
+++ b/apis/policy/v1beta1/zz_generated.die.go
@@ -214,9 +214,13 @@ func (d *PodSecurityPolicyDie) DieStampAt(jp string, fn interface{}) *PodSecurit
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodSecurityPolicyDie) DieWith(fn func(d *PodSecurityPolicyDie)) *PodSecurityPolicyDie {
+func (d *PodSecurityPolicyDie) DieWith(fns ...func(d *PodSecurityPolicyDie)) *PodSecurityPolicyDie {
 	nd := PodSecurityPolicyBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -460,9 +464,13 @@ func (d *PodSecurityPolicySpecDie) DieStampAt(jp string, fn interface{}) *PodSec
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PodSecurityPolicySpecDie) DieWith(fn func(d *PodSecurityPolicySpecDie)) *PodSecurityPolicySpecDie {
+func (d *PodSecurityPolicySpecDie) DieWith(fns ...func(d *PodSecurityPolicySpecDie)) *PodSecurityPolicySpecDie {
 	nd := PodSecurityPolicySpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -810,9 +818,13 @@ func (d *HostPortRangeDie) DieStampAt(jp string, fn interface{}) *HostPortRangeD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *HostPortRangeDie) DieWith(fn func(d *HostPortRangeDie)) *HostPortRangeDie {
+func (d *HostPortRangeDie) DieWith(fns ...func(d *HostPortRangeDie)) *HostPortRangeDie {
 	nd := HostPortRangeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1002,9 +1014,13 @@ func (d *SELinuxStrategyOptionsDie) DieStampAt(jp string, fn interface{}) *SELin
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SELinuxStrategyOptionsDie) DieWith(fn func(d *SELinuxStrategyOptionsDie)) *SELinuxStrategyOptionsDie {
+func (d *SELinuxStrategyOptionsDie) DieWith(fns ...func(d *SELinuxStrategyOptionsDie)) *SELinuxStrategyOptionsDie {
 	nd := SELinuxStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1194,9 +1210,13 @@ func (d *RunAsUserStrategyOptionsDie) DieStampAt(jp string, fn interface{}) *Run
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RunAsUserStrategyOptionsDie) DieWith(fn func(d *RunAsUserStrategyOptionsDie)) *RunAsUserStrategyOptionsDie {
+func (d *RunAsUserStrategyOptionsDie) DieWith(fns ...func(d *RunAsUserStrategyOptionsDie)) *RunAsUserStrategyOptionsDie {
 	nd := RunAsUserStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1386,9 +1406,13 @@ func (d *RunAsGroupStrategyOptionsDie) DieStampAt(jp string, fn interface{}) *Ru
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RunAsGroupStrategyOptionsDie) DieWith(fn func(d *RunAsGroupStrategyOptionsDie)) *RunAsGroupStrategyOptionsDie {
+func (d *RunAsGroupStrategyOptionsDie) DieWith(fns ...func(d *RunAsGroupStrategyOptionsDie)) *RunAsGroupStrategyOptionsDie {
 	nd := RunAsGroupStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1578,9 +1602,13 @@ func (d *SupplementalGroupsStrategyOptionsDie) DieStampAt(jp string, fn interfac
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *SupplementalGroupsStrategyOptionsDie) DieWith(fn func(d *SupplementalGroupsStrategyOptionsDie)) *SupplementalGroupsStrategyOptionsDie {
+func (d *SupplementalGroupsStrategyOptionsDie) DieWith(fns ...func(d *SupplementalGroupsStrategyOptionsDie)) *SupplementalGroupsStrategyOptionsDie {
 	nd := SupplementalGroupsStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1770,9 +1798,13 @@ func (d *FSGroupStrategyOptionsDie) DieStampAt(jp string, fn interface{}) *FSGro
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *FSGroupStrategyOptionsDie) DieWith(fn func(d *FSGroupStrategyOptionsDie)) *FSGroupStrategyOptionsDie {
+func (d *FSGroupStrategyOptionsDie) DieWith(fns ...func(d *FSGroupStrategyOptionsDie)) *FSGroupStrategyOptionsDie {
 	nd := FSGroupStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1962,9 +1994,13 @@ func (d *AllowedHostPathDie) DieStampAt(jp string, fn interface{}) *AllowedHostP
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AllowedHostPathDie) DieWith(fn func(d *AllowedHostPathDie)) *AllowedHostPathDie {
+func (d *AllowedHostPathDie) DieWith(fns ...func(d *AllowedHostPathDie)) *AllowedHostPathDie {
 	nd := AllowedHostPathBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2156,9 +2192,13 @@ func (d *AllowedFlexVolumeDie) DieStampAt(jp string, fn interface{}) *AllowedFle
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AllowedFlexVolumeDie) DieWith(fn func(d *AllowedFlexVolumeDie)) *AllowedFlexVolumeDie {
+func (d *AllowedFlexVolumeDie) DieWith(fns ...func(d *AllowedFlexVolumeDie)) *AllowedFlexVolumeDie {
 	nd := AllowedFlexVolumeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2341,9 +2381,13 @@ func (d *AllowedCSIDriverDie) DieStampAt(jp string, fn interface{}) *AllowedCSID
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *AllowedCSIDriverDie) DieWith(fn func(d *AllowedCSIDriverDie)) *AllowedCSIDriverDie {
+func (d *AllowedCSIDriverDie) DieWith(fns ...func(d *AllowedCSIDriverDie)) *AllowedCSIDriverDie {
 	nd := AllowedCSIDriverBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2526,9 +2570,13 @@ func (d *RuntimeClassStrategyOptionsDie) DieStampAt(jp string, fn interface{}) *
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *RuntimeClassStrategyOptionsDie) DieWith(fn func(d *RuntimeClassStrategyOptionsDie)) *RuntimeClassStrategyOptionsDie {
+func (d *RuntimeClassStrategyOptionsDie) DieWith(fns ...func(d *RuntimeClassStrategyOptionsDie)) *RuntimeClassStrategyOptionsDie {
 	nd := RuntimeClassStrategyOptionsBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2718,9 +2766,13 @@ func (d *IDRangeDie) DieStampAt(jp string, fn interface{}) *IDRangeDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *IDRangeDie) DieWith(fn func(d *IDRangeDie)) *IDRangeDie {
+func (d *IDRangeDie) DieWith(fns ...func(d *IDRangeDie)) *IDRangeDie {
 	nd := IDRangeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/scheduling/v1/zz_generated.die.go
+++ b/apis/scheduling/v1/zz_generated.die.go
@@ -214,9 +214,13 @@ func (d *PriorityClassDie) DieStampAt(jp string, fn interface{}) *PriorityClassD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *PriorityClassDie) DieWith(fn func(d *PriorityClassDie)) *PriorityClassDie {
+func (d *PriorityClassDie) DieWith(fns ...func(d *PriorityClassDie)) *PriorityClassDie {
 	nd := PriorityClassBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/storage/v1/zz_generated.die.go
+++ b/apis/storage/v1/zz_generated.die.go
@@ -215,9 +215,13 @@ func (d *CSIDriverDie) DieStampAt(jp string, fn interface{}) *CSIDriverDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CSIDriverDie) DieWith(fn func(d *CSIDriverDie)) *CSIDriverDie {
+func (d *CSIDriverDie) DieWith(fns ...func(d *CSIDriverDie)) *CSIDriverDie {
 	nd := CSIDriverBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -461,9 +465,13 @@ func (d *CSIDriverSpecDie) DieStampAt(jp string, fn interface{}) *CSIDriverSpecD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CSIDriverSpecDie) DieWith(fn func(d *CSIDriverSpecDie)) *CSIDriverSpecDie {
+func (d *CSIDriverSpecDie) DieWith(fns ...func(d *CSIDriverSpecDie)) *CSIDriverSpecDie {
 	nd := CSIDriverSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -731,9 +739,13 @@ func (d *TokenRequestDie) DieStampAt(jp string, fn interface{}) *TokenRequestDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *TokenRequestDie) DieWith(fn func(d *TokenRequestDie)) *TokenRequestDie {
+func (d *TokenRequestDie) DieWith(fns ...func(d *TokenRequestDie)) *TokenRequestDie {
 	nd := TokenRequestBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -938,9 +950,13 @@ func (d *CSINodeDie) DieStampAt(jp string, fn interface{}) *CSINodeDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CSINodeDie) DieWith(fn func(d *CSINodeDie)) *CSINodeDie {
+func (d *CSINodeDie) DieWith(fns ...func(d *CSINodeDie)) *CSINodeDie {
 	nd := CSINodeBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1184,9 +1200,13 @@ func (d *CSINodeSpecDie) DieStampAt(jp string, fn interface{}) *CSINodeSpecDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CSINodeSpecDie) DieWith(fn func(d *CSINodeSpecDie)) *CSINodeSpecDie {
+func (d *CSINodeSpecDie) DieWith(fns ...func(d *CSINodeSpecDie)) *CSINodeSpecDie {
 	nd := CSINodeSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1369,9 +1389,13 @@ func (d *CSINodeDriverDie) DieStampAt(jp string, fn interface{}) *CSINodeDriverD
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CSINodeDriverDie) DieWith(fn func(d *CSINodeDriverDie)) *CSINodeDriverDie {
+func (d *CSINodeDriverDie) DieWith(fns ...func(d *CSINodeDriverDie)) *CSINodeDriverDie {
 	nd := CSINodeDriverBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1575,9 +1599,13 @@ func (d *VolumeNodeResourcesDie) DieStampAt(jp string, fn interface{}) *VolumeNo
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeNodeResourcesDie) DieWith(fn func(d *VolumeNodeResourcesDie)) *VolumeNodeResourcesDie {
+func (d *VolumeNodeResourcesDie) DieWith(fns ...func(d *VolumeNodeResourcesDie)) *VolumeNodeResourcesDie {
 	nd := VolumeNodeResourcesBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -1775,9 +1803,13 @@ func (d *StorageClassDie) DieStampAt(jp string, fn interface{}) *StorageClassDie
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *StorageClassDie) DieWith(fn func(d *StorageClassDie)) *StorageClassDie {
+func (d *StorageClassDie) DieWith(fns ...func(d *StorageClassDie)) *StorageClassDie {
 	nd := StorageClassBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2069,9 +2101,13 @@ func (d *VolumeAttachmentDie) DieStampAt(jp string, fn interface{}) *VolumeAttac
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeAttachmentDie) DieWith(fn func(d *VolumeAttachmentDie)) *VolumeAttachmentDie {
+func (d *VolumeAttachmentDie) DieWith(fns ...func(d *VolumeAttachmentDie)) *VolumeAttachmentDie {
 	nd := VolumeAttachmentBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2331,9 +2367,13 @@ func (d *VolumeAttachmentSpecDie) DieStampAt(jp string, fn interface{}) *VolumeA
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeAttachmentSpecDie) DieWith(fn func(d *VolumeAttachmentSpecDie)) *VolumeAttachmentSpecDie {
+func (d *VolumeAttachmentSpecDie) DieWith(fns ...func(d *VolumeAttachmentSpecDie)) *VolumeAttachmentSpecDie {
 	nd := VolumeAttachmentSpecBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2530,9 +2570,13 @@ func (d *VolumeAttachmentSourceDie) DieStampAt(jp string, fn interface{}) *Volum
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeAttachmentSourceDie) DieWith(fn func(d *VolumeAttachmentSourceDie)) *VolumeAttachmentSourceDie {
+func (d *VolumeAttachmentSourceDie) DieWith(fns ...func(d *VolumeAttachmentSourceDie)) *VolumeAttachmentSourceDie {
 	nd := VolumeAttachmentSourceBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2722,9 +2766,13 @@ func (d *VolumeAttachmentStatusDie) DieStampAt(jp string, fn interface{}) *Volum
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeAttachmentStatusDie) DieWith(fn func(d *VolumeAttachmentStatusDie)) *VolumeAttachmentStatusDie {
+func (d *VolumeAttachmentStatusDie) DieWith(fns ...func(d *VolumeAttachmentStatusDie)) *VolumeAttachmentStatusDie {
 	nd := VolumeAttachmentStatusBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 
@@ -2928,9 +2976,13 @@ func (d *VolumeErrorDie) DieStampAt(jp string, fn interface{}) *VolumeErrorDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *VolumeErrorDie) DieWith(fn func(d *VolumeErrorDie)) *VolumeErrorDie {
+func (d *VolumeErrorDie) DieWith(fns ...func(d *VolumeErrorDie)) *VolumeErrorDie {
 	nd := VolumeErrorBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/apis/storage/v1beta1/zz_generated.die.go
+++ b/apis/storage/v1beta1/zz_generated.die.go
@@ -215,9 +215,13 @@ func (d *CSIStorageCapacityDie) DieStampAt(jp string, fn interface{}) *CSIStorag
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *CSIStorageCapacityDie) DieWith(fn func(d *CSIStorageCapacityDie)) *CSIStorageCapacityDie {
+func (d *CSIStorageCapacityDie) DieWith(fns ...func(d *CSIStorageCapacityDie)) *CSIStorageCapacityDie {
 	nd := CSIStorageCapacityBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 

--- a/diegen/die/traverse.go
+++ b/diegen/die/traverse.go
@@ -413,9 +413,13 @@ func (c *copyMethodMaker) generateDieStampMethodFor(die Die) {
 func (c *copyMethodMaker) generateDieWithMethodFor(die Die) {
 	c.Linef("")
 	c.Linef("// DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.")
-	c.Linef("func (d *%s) DieWith(fn func(d *%s)) *%s {", die.Type, die.Type, die.Type)
+	c.Linef("func (d *%s) DieWith(fns ...func(d *%s)) *%s {", die.Type, die.Type, die.Type)
 	c.Linef("	nd := %s.DieFeed(d.DieRelease()).DieImmutable(false)", die.Blank)
-	c.Linef("	fn(nd)")
+	c.Linef("	for _, fn := range fns {")
+	c.Linef("		if fn != nil {")
+	c.Linef("			fn(nd)")
+	c.Linef("		}")
+	c.Linef("	}")
 	c.Linef("	return d.DieFeed(nd.DieRelease())")
 	c.Linef("}")
 }

--- a/testing/sandbox/zz_generated.die.go
+++ b/testing/sandbox/zz_generated.die.go
@@ -194,9 +194,13 @@ func (d *DirectDie) DieStampAt(jp string, fn interface{}) *DirectDie {
 }
 
 // DieWith returns a new die after passing the current die to the callback function. The passed die is mutable.
-func (d *DirectDie) DieWith(fn func(d *DirectDie)) *DirectDie {
+func (d *DirectDie) DieWith(fns ...func(d *DirectDie)) *DirectDie {
 	nd := DirectBlank.DieFeed(d.DieRelease()).DieImmutable(false)
-	fn(nd)
+	for _, fn := range fns {
+		if fn != nil {
+			fn(nd)
+		}
+	}
 	return d.DieFeed(nd.DieRelease())
 }
 


### PR DESCRIPTION
Each func is executed in order returning the resulting die. It is equivlent to chaining multiple DieWith calls in serries.